### PR TITLE
Fix crate rebuilding

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,10 +45,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rerun-if-changed=external/grpc-gateway");
 
         tonic_build::configure()
+            .emit_rerun_if_changed(false)
             .build_server(false)
             .build_client(false)
             .compile(NON_CLIENT_PROTOS, INCLUDES)?;
         tonic_build::configure()
+            .emit_rerun_if_changed(false)
             .build_server(false)
             .build_client(true)
             .compile(CLIENT_PROTOS, INCLUDES)?;


### PR DESCRIPTION
Previously, crate will be rebuilt on every `cargo check`  regardless of proto files changes.

You can check it with:
`CARGO_LOG=cargo::core::compiler::fingerprint=info cargo c --all-features`