### PR TITLE
refactor: Make ServiceAccountError Send + Sync

### DIFF
--- a/src/credentials/service_account.rs
+++ b/src/credentials/service_account.rs
@@ -71,7 +71,7 @@ custom_error! {
         Json{source: serde_json::Error} = "could not parse json: {source}",
         Key{source: jsonwebtoken::errors::Error} = "could not parse RSA key: {source}",
         AudienceUrl{source: openidconnect::url::ParseError} = "audience url could not be parsed: {source}",
-        DiscoveryError{source: Box<dyn std::error::Error>} = "could not discover OIDC document: {source}",
+        DiscoveryError{source: Box<dyn std::error::Error + Send + Sync>} = "could not discover OIDC document: {source}",
         TokenEndpointMissing = "OIDC document does not contain token endpoint",
         HttpError{source: openidconnect::reqwest::Error<reqwest::Error>} = "http error: {source}",
         UrlEncodeError = "could not encode url params for token request",


### PR DESCRIPTION
`ServiceAccountError` is currently not `Send` and `Sync`, causing incompatibilities with the error handling I'm using, [error-stack](https://docs.rs/error-stack/latest/error_stack/). Would changing this cause any problems for you?

Best,
Emelie Graven