### PR TITLE
feat: added optional extra fields to introspection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ interceptors = ["api", "credentials", "dep:time", "dep:tokio"]
 ## The OIDC features are required for some of the web framework features.
 oidc = [
     "credentials",
-    "dep:base64",
+    "dep:base64-compat",
 ]
 
 ## Feature that enables support for the [rocket framework](https://rocket.rs/).
@@ -63,7 +63,7 @@ rocket = [
 ]
 
 [dependencies]
-base64 = { version = "0.21.1", optional = true }
+base64-compat = { version = "1", optional = true }
 custom_error = "1.9.2"
 document-features = { version = "0.2", optional = true }
 jsonwebtoken = { version = "8.3.0", optional = true }


### PR DESCRIPTION
When a token is requested with zitadel scopes such as `urn:zitadel:iam:user:resourceowner` or `urn:zitadel:iam:user:metadata`, extra fields are available in the introspection result.

This change adds support for the additional extra fields.

Because the existing code, and this change, use a [deprecated api](https://docs.rs/base64/latest/base64/fn.decode.html) in the `base64` crate, the `base64` dependency has been changed to the stable [base64-compat crate](https://docs.rs/base64-compat/1.0.0/base64/). This is just personal taste, and I would happy to convert the base64 calls to the newer api if you would prefer.


Fixes #437