### PR TITLE
feat: Use reqwest with rusttls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ jsonwebtoken = { version = "8.3.0", optional = true }
 openidconnect = { version = "3.0.0", optional = true }
 prost = { version = "0.11", optional = true }
 prost-types = { version = "0.11", optional = true }
-reqwest = { version = "0.11.18", features = ["json"], optional = true }
+reqwest = { version = "0.11.18", features = ["json", "rustls-tls"], default-features = false, optional = true }
 rocket = { version = "0.5.0-rc.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
By removing the `reqwest` default features and using `rustls-tls` instead, the Zitadel crate no longer has both `openssl` as an additional dependency to `rustls`.

Fixes #445 