### PR TITLE
feat(clients): Add v2 API clients and centralize client generation

### DIFF
--- a/examples/fetch_profile_with_pat.rs
+++ b/examples/fetch_profile_with_pat.rs
@@ -1,6 +1,4 @@
-use zitadel::api::{
-    clients::with_access_token::create_auth_client, zitadel::auth::v1::GetMyUserRequest,
-};
+use zitadel::api::{clients::ClientBuilder, zitadel::auth::v1::GetMyUserRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,7 +6,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "dEnGhIFs3VnqcQU5D2zRSeiarB1nwH6goIKY0J8MWZbsnWcTuu1C59lW9DgCq1y096GYdXA";
     const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
 
-    let mut client = create_auth_client(ZITADEL_URL, PERSONAL_ACCESS_TOKEN).await?;
+    let mut client = ClientBuilder::new(ZITADEL_URL)
+        .with_access_token(PERSONAL_ACCESS_TOKEN)
+        .build_auth_client()
+        .await?;
     let user = client.get_my_user(GetMyUserRequest {}).await?.into_inner();
     println!("{:#?}", user);
 

--- a/examples/fetch_profile_with_service_account.rs
+++ b/examples/fetch_profile_with_service_account.rs
@@ -1,5 +1,5 @@
 use zitadel::{
-    api::{clients::with_service_account::create_auth_client, zitadel::auth::v1::GetMyUserRequest},
+    api::{clients::ClientBuilder, zitadel::auth::v1::GetMyUserRequest},
     credentials::{AuthenticationOptions, ServiceAccount},
 };
 
@@ -14,15 +14,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }"#;
     const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
     let service_account = ServiceAccount::load_from_json(SERVICE_ACCOUNT)?;
-    let mut client = create_auth_client(
-        ZITADEL_URL,
-        &service_account,
-        Some(AuthenticationOptions {
-            api_access: true,
-            ..Default::default()
-        }),
-    )
-    .await?;
+    let mut client = ClientBuilder::new(ZITADEL_URL)
+        .with_service_account(
+            &service_account,
+            Some(AuthenticationOptions {
+                api_access: true,
+                ..Default::default()
+            }),
+        )
+        .build_auth_client()
+        .await?;
     let user = client.get_my_user(GetMyUserRequest {}).await?.into_inner();
     println!("{:#?}", user);
 

--- a/src/api/clients.rs
+++ b/src/api/clients.rs
@@ -9,10 +9,15 @@ use custom_error::custom_error;
 use tonic::codegen::InterceptedService;
 use tonic::service::Interceptor;
 use tonic::transport::{Channel, Endpoint};
+use tonic::{Request, Status};
 
-use crate::api::interceptors::{
-    AccessTokenInterceptor, ChainedInterceptor, ServiceAccountInterceptor,
-};
+use crate::api::interceptors::{AccessTokenInterceptor, ServiceAccountInterceptor};
+use crate::api::zitadel::oidc::v2beta::oidc_service_client::OidcServiceClient;
+use crate::api::zitadel::org::v2beta::organization_service_client::OrganizationServiceClient;
+use crate::api::zitadel::session::v2beta::session_service_client::SessionServiceClient;
+use crate::api::zitadel::settings::v2beta::settings_service_client::SettingsServiceClient;
+use crate::api::zitadel::system::v1::system_service_client::SystemServiceClient;
+use crate::api::zitadel::user::v2beta::user_service_client::UserServiceClient;
 use crate::credentials::{AuthenticationOptions, ServiceAccount};
 
 use super::zitadel::{
@@ -28,55 +33,55 @@ custom_error! {
         ConnectionError = "could not connect to provided endpoint",
 }
 
-async fn get_channel(api_endpoint: &str) -> Result<Channel, ClientError> {
-    Endpoint::from_shared(api_endpoint.to_string())
-        .map_err(|_| ClientError::InvalidUrl)?
-        .connect()
-        .await
-        .map_err(|_| ClientError::ConnectionError)
-}
-
-/// Create a new [`AdminServiceClient`] to access the
-/// [Admin API](https://docs.zitadel.com/docs/apis/proto/admin) of ZITADEL.
-///
-/// This client has no interceptors attached, therefore, authentication
-/// must be handled for each call.
-///
-/// ### Errors
-///
-/// This function returns a [`ClientError`] if the provided API endpoint
-/// cannot be parsed into a valid URL or if the connection to the endpoint
-/// is not possible.
-///
-/// ### Example
-/// ```
-/// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-/// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-/// let client = zitadel::api::clients::create_admin_client(ZITADEL_URL).await?;
-/// # Ok(())
-/// # }
-/// ```
-#[cfg(feature = "api")]
-pub async fn create_admin_client(
-    api_endpoint: &str,
-) -> Result<AdminServiceClient<Channel>, ClientError> {
-    let channel = get_channel(api_endpoint).await?;
-    Ok(AdminServiceClient::new(channel))
-}
-
 enum AuthType {
     None,
     AccessToken(String),
     ServiceAccount(ServiceAccount, Option<AuthenticationOptions>),
 }
 
+/// Helper [Interceptor] that allows chaining of multiple interceptors.
+/// This is used to help return the same type in all builder methods like
+/// [ClientBuilder::build_management_client]. Otherwise, each interceptor
+/// would create its own return type. With this interceptor, the return type
+/// stays the same and is not dependent on the authentication type used.
+/// The builder can always return `Client<InterceptedService<Channel, ChainedInterceptor>>`.
+pub struct ChainedInterceptor {
+    interceptors: Vec<Box<dyn Interceptor>>,
+}
+
+impl ChainedInterceptor {
+    pub(crate) fn new() -> Self {
+        Self {
+            interceptors: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add_interceptor(mut self, interceptor: Box<dyn Interceptor>) -> Self {
+        self.interceptors.push(interceptor);
+        self
+    }
+}
+
+impl Interceptor for ChainedInterceptor {
+    fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
+        let mut request = request;
+        for interceptor in &mut self.interceptors {
+            request = interceptor.call(request)?;
+        }
+        Ok(request)
+    }
+}
+
+/// A builder to create configured gRPC clients for ZITADEL API access.
+/// The builder accepts the api endpoint and (depending on activated features)
+/// an authentication method.
 pub struct ClientBuilder {
     api_endpoint: String,
     auth_type: AuthType,
 }
 
 impl ClientBuilder {
+    /// Create a new client builder with the the provided endpoint.
     pub fn new(api_endpoint: &str) -> Self {
         Self {
             api_endpoint: api_endpoint.to_string(),
@@ -84,11 +89,25 @@ impl ClientBuilder {
         }
     }
 
+    /// Configure the client builder to use a provided access token.
+    /// This can be a pre-fetched token from ZITADEL or some other form
+    /// of a valid access token like a personal access token (PAT).
+    ///
+    /// Clients with this authentication method will have the [`AccessTokenInterceptor`]
+    /// attached.
+    #[cfg(feature = "interceptors")]
     pub fn with_access_token(mut self, access_token: &str) -> Self {
         self.auth_type = AuthType::AccessToken(access_token.to_string());
         self
     }
 
+    /// Configure the client builder to use a [`ServiceAccount`][crate::credentials::ServiceAccount].
+    /// The service account will be used to fetch a valid access token from ZITADEL.
+    ///
+    /// Clients with this authentication method will have the
+    /// [`ServiceAccountInterceptor`][crate::api::interceptors::ServiceAccountInterceptor] attached
+    /// that fetches an access token from ZITADEL and renewes it when it expires.
+    #[cfg(feature = "interceptors")]
     pub fn with_service_account(
         mut self,
         service_account: &ServiceAccount,
@@ -98,6 +117,16 @@ impl ClientBuilder {
         self
     }
 
+    /// Create a new [`AdminServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
     pub async fn build_admin_client(
         &self,
     ) -> Result<AdminServiceClient<InterceptedService<Channel, ChainedInterceptor>>, Box<dyn Error>>
@@ -109,6 +138,16 @@ impl ClientBuilder {
         ))
     }
 
+    /// Create a new [`AuthServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
     pub async fn build_auth_client(
         &self,
     ) -> Result<AuthServiceClient<InterceptedService<Channel, ChainedInterceptor>>, Box<dyn Error>>
@@ -120,6 +159,16 @@ impl ClientBuilder {
         ))
     }
 
+    /// Create a new [`ManagementServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
     pub async fn build_management_client(
         &self,
     ) -> Result<
@@ -128,6 +177,136 @@ impl ClientBuilder {
     > {
         let channel = get_channel(&self.api_endpoint).await?;
         Ok(ManagementServiceClient::with_interceptor(
+            channel,
+            self.get_chained_interceptor(),
+        ))
+    }
+
+    /// Create a new [`OidcServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
+    pub async fn build_oidc_client(
+        &self,
+    ) -> Result<OidcServiceClient<InterceptedService<Channel, ChainedInterceptor>>, Box<dyn Error>>
+    {
+        let channel = get_channel(&self.api_endpoint).await?;
+        Ok(OidcServiceClient::with_interceptor(
+            channel,
+            self.get_chained_interceptor(),
+        ))
+    }
+
+    /// Create a new [`OrganizationServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
+    pub async fn build_organization_client(
+        &self,
+    ) -> Result<
+        OrganizationServiceClient<InterceptedService<Channel, ChainedInterceptor>>,
+        Box<dyn Error>,
+    > {
+        let channel = get_channel(&self.api_endpoint).await?;
+        Ok(OrganizationServiceClient::with_interceptor(
+            channel,
+            self.get_chained_interceptor(),
+        ))
+    }
+
+    /// Create a new [`SessionServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
+    pub async fn build_session_client(
+        &self,
+    ) -> Result<SessionServiceClient<InterceptedService<Channel, ChainedInterceptor>>, Box<dyn Error>>
+    {
+        let channel = get_channel(&self.api_endpoint).await?;
+        Ok(SessionServiceClient::with_interceptor(
+            channel,
+            self.get_chained_interceptor(),
+        ))
+    }
+
+    /// Create a new [`SettingsServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
+    pub async fn build_settings_client(
+        &self,
+    ) -> Result<
+        SettingsServiceClient<InterceptedService<Channel, ChainedInterceptor>>,
+        Box<dyn Error>,
+    > {
+        let channel = get_channel(&self.api_endpoint).await?;
+        Ok(SettingsServiceClient::with_interceptor(
+            channel,
+            self.get_chained_interceptor(),
+        ))
+    }
+
+    /// Create a new [`SystemServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
+    pub async fn build_system_client(
+        &self,
+    ) -> Result<SystemServiceClient<InterceptedService<Channel, ChainedInterceptor>>, Box<dyn Error>>
+    {
+        let channel = get_channel(&self.api_endpoint).await?;
+        Ok(SystemServiceClient::with_interceptor(
+            channel,
+            self.get_chained_interceptor(),
+        ))
+    }
+
+    /// Create a new [`UserServiceClient`].
+    ///
+    /// Depending on the configured authentication method, the client has
+    /// specialised interceptors attached.
+    ///
+    /// ### Errors
+    ///
+    /// This function returns a [`ClientError`] if the provided API endpoint
+    /// cannot be parsed into a valid URL or if the connection to the endpoint
+    /// is not possible.
+    pub async fn build_user_client(
+        &self,
+    ) -> Result<UserServiceClient<InterceptedService<Channel, ChainedInterceptor>>, Box<dyn Error>>
+    {
+        let channel = get_channel(&self.api_endpoint).await?;
+        Ok(UserServiceClient::with_interceptor(
             channel,
             self.get_chained_interceptor(),
         ))
@@ -155,325 +334,76 @@ impl ClientBuilder {
     }
 }
 
-/// Create a new [`AuthServiceClient`] to access the
-/// [Auth API](https://docs.zitadel.com/docs/apis/proto/auth) of ZITADEL.
-///
-/// This client has no interceptors attached, therefore, authentication
-/// must be handled for each call.
-///
-/// ### Errors
-///
-/// This function returns a [`ClientError`] if the provided API endpoint
-/// cannot be parsed into a valid URL or if the connection to the endpoint
-/// is not possible.
-///
-/// ### Example
-/// ```
-/// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-/// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-/// let client = zitadel::api::clients::create_auth_client(ZITADEL_URL).await?;
-/// # Ok(())
-/// # }
-/// ```
-#[cfg(feature = "api")]
-pub async fn create_auth_client(
-    api_endpoint: &str,
-) -> Result<AuthServiceClient<Channel>, ClientError> {
-    let channel = get_channel(api_endpoint).await?;
-    Ok(AuthServiceClient::new(channel))
+async fn get_channel(api_endpoint: &str) -> Result<Channel, ClientError> {
+    Endpoint::from_shared(api_endpoint.to_string())
+        .map_err(|_| ClientError::InvalidUrl)?
+        .connect()
+        .await
+        .map_err(|_| ClientError::ConnectionError)
 }
 
-/// Create a new [`ManagementServiceClient`] to access the
-/// [Management API](https://docs.zitadel.com/docs/apis/proto/management) of ZITADEL.
-///
-/// This client has no interceptors attached, therefore, authentication
-/// must be handled for each call.
-///
-/// ### Errors
-///
-/// This function returns a [`ClientError`] if the provided API endpoint
-/// cannot be parsed into a valid URL or if the connection to the endpoint
-/// is not possible.
-///
-/// ### Example
-/// ```
-/// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-/// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-/// let client = zitadel::api::clients::create_management_client(ZITADEL_URL).await?;
-/// # Ok(())
-/// # }
-/// ```
-#[cfg(feature = "api")]
-pub async fn create_management_client(
-    api_endpoint: &str,
-) -> Result<ManagementServiceClient<Channel>, ClientError> {
-    let channel = get_channel(api_endpoint).await?;
-    Ok(ManagementServiceClient::new(channel))
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// Module with convenience functions to create clients for ZITADEL
-/// API access with an arbitrary access token. The access token
-/// may be one of the following types:
-/// - User provided access token that came from the users request
-/// - Service account personal access key
-/// - Some other means of fetching a valid access token
-#[cfg(all(feature = "api", feature = "interceptors"))]
-pub mod with_access_token {
-    use tonic::codegen::InterceptedService;
-    use tonic::transport::Channel;
-
-    use crate::api::interceptors::AccessTokenInterceptor;
-    use crate::api::zitadel::{
-        admin::v1::admin_service_client::AdminServiceClient,
-        auth::v1::auth_service_client::AuthServiceClient,
-        management::v1::management_service_client::ManagementServiceClient,
-    };
-
-    use super::{get_channel, ClientError};
-
-    /// Create a new [`AdminServiceClient`] to access the
-    /// [Admin API](https://docs.zitadel.com/docs/apis/proto/admin) of ZITADEL.
-    ///
-    /// This client has the [`AccessTokenInterceptor`][crate::api::interceptors::AccessTokenInterceptor] attached that
-    /// allows authentication against the ZITADEL API with some access token.
-    /// This could be a personal access token of a service account.
-    ///
-    /// ### Errors
-    ///
-    /// This function returns a [`ClientError`] if the provided API endpoint
-    /// cannot be parsed into a valid URL or if the connection to the endpoint
-    /// is not possible.
-    ///
-    /// ### Example
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-    /// let client = zitadel::api::clients::with_access_token::create_admin_client(ZITADEL_URL, "token").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "api")]
-    pub async fn create_admin_client(
-        api_endpoint: &str,
-        access_token: &str,
-    ) -> Result<AdminServiceClient<InterceptedService<Channel, AccessTokenInterceptor>>, ClientError>
+    const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
+    const SERVICE_ACCOUNT: &str = r#"
     {
-        let channel = get_channel(api_endpoint).await?;
-        Ok(AdminServiceClient::with_interceptor(
-            channel,
-            AccessTokenInterceptor::new(access_token),
-        ))
+        "type": "serviceaccount",
+        "keyId": "181828078849229057",
+        "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEA9VIWALQqzx1ypi42t7MG4KSOMldD10brsEUjTcjqxhl6TJrP\nsjaNKWArnV/XH+6ZKRd55mUEFFx9VflqdwQtMVPjZKXpV4cFDiPwf1Z1h1DS6im4\nSo7eKR7OGb7TLBhwt7i2UPF4WnxBhTp/M6pG5kCJ1t8glIo5yRbrILXObRmvNWMz\nVIFAyw68NDZGYNhnR8AT43zjeJTFXG/suuEoXO/mMmMjsYY8kS0BbiQeq5t5hIrr\na/odswkDPn5Zd4P91iJHDnYlgfJuo3oRmgpOj/dDsl+vTol+vveeMO4TXPwZcl36\ngUNPok7nd6BA3gqmOS+fMImzmZB42trghARXXwIDAQABAoIBAQCbMOGQcml+ep+T\ntzqQPWYFaLQ37nKRVmE1Mpeh1o+G4Ik4utrXX6EvYpJUzVN29ObZUuufr5nEE7qK\nT+1k+zRntyzr9/VElLrC9kNnGtfg0WWMEvZt3DF4i+9P5CMNCy0LXIOhcxBzFZYR\nZS8hDQArGvrX/nFK5qKlrqTyHXFIHDFa6z59ErhXEnsTgRvx/Mo+6UkdBkHsKnlJ\nAbXqXFbfz6nDsF1DgRra5ODn1k8nZqnC/YcssE7/dlbuByz10ECkOSzqYcfufnsb\n9N1Ld4Xlj3yzsqPFzEJyHHm9eEHQXsPavaXiM64/+zpsksLscEIE/0KtIy5tngpZ\nSCqZAcj5AoGBAPb1bQFWUBmmUuSTtSymsxgXghJiJ3r+jJgdGbkv2IsRTs4En5Sz\n0SbPE1YWmMDDgTacJlB4/XiaojQ/j1EEY17inxYomE72UL6/ET7ycsEw3e9ALuD5\np0y2Sdzes2biH30bw5jD8kJ+hV18T745KtzrwSH4I0lAjnkmiH+0S67VAoGBAP5N\nTtAp/Qdxh9GjNSw1J7KRLtJrrr0pPrJ9av4GoFoWlz+Qw2X3dl8rjG3Bqz9LPV7A\ngiHMel8WTmdIM/S3F4Q3ufEfE+VzG+gncWd9SJfX5/LVhatPzTGLNsY7AYGEpSwT\n5/0anS1mHrLwsVcPrZnigekr5A5mfZl6nxtOnE9jAoGBALACqacbUkmFrmy1DZp+\nUQSptI3PoR3bEG9VxkCjZi1vr3/L8cS1CCslyT1BK6uva4d1cSVHpjfv1g1xA38V\nppE46XOMiUk16sSYPv1jJQCmCHd9givcIy3cefZOTwTTwueTAyv888wKipjfgaIs\n8my0JllEljmeJi0Ylo6V/J7lAoGBAIFqRlmZhLNtC3mcXUsKIhG14OYk9uA9RTMA\nsJpmNOSj6oTm3wndTdhRCT4x+TxUxf6aaZ9ZuEz7xRq6m/ZF1ynqUi5ramyyj9kt\neYD5OSBNODVUhJoSGpLEDjQDg1iucIBmAQHFsYeRGL5nz1hHGkneA87uDzlk3zZk\nOORktReRAoGAGUfU2UfaniAlqrZsSma3ZTlvJWs1x8cbVDyKTYMX5ShHhp+cA86H\nYjSSol6GI2wQPP+qIvZ1E8XyzD2miMJabl92/WY0tHejNNBEHwD8uBZKrtMoFWM7\nWJNl+Xneu/sT8s4pP2ng6QE7jpHXi2TUNmSlgQry9JN2AmA9TuSTW2Y=\n-----END RSA PRIVATE KEY-----\n",
+        "userId": "181828061098934529"
+    }"#;
+
+    #[test]
+    fn client_builder_without_auth_passes_requests() {
+        let mut interceptor = ClientBuilder::new(ZITADEL_URL).get_chained_interceptor();
+        let request = Request::new(());
+
+        assert!(request.metadata().is_empty());
+
+        let request = interceptor.call(request).unwrap();
+
+        assert!(request.metadata().is_empty());
     }
 
-    /// Create a new [`AuthServiceClient`] to access the
-    /// [Auth API](https://docs.zitadel.com/docs/apis/proto/auth) of ZITADEL.
-    ///
-    /// This client has the [`AccessTokenInterceptor`][crate::api::interceptors::AccessTokenInterceptor] attached that
-    /// allows authentication against the ZITADEL API with some access token.
-    /// This could be a personal access token of a service account.
-    ///
-    /// ### Errors
-    ///
-    /// This function returns a [`ClientError`] if the provided API endpoint
-    /// cannot be parsed into a valid URL or if the connection to the endpoint
-    /// is not possible.
-    ///
-    /// ### Example
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-    /// let client = zitadel::api::clients::with_access_token::create_auth_client(ZITADEL_URL, "token").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "api")]
-    pub async fn create_auth_client(
-        api_endpoint: &str,
-        access_token: &str,
-    ) -> Result<AuthServiceClient<InterceptedService<Channel, AccessTokenInterceptor>>, ClientError>
-    {
-        let channel = get_channel(api_endpoint).await?;
-        Ok(AuthServiceClient::with_interceptor(
-            channel,
-            AccessTokenInterceptor::new(access_token),
-        ))
+    #[test]
+    fn client_builder_with_access_token_attaches_it() {
+        let mut interceptor = ClientBuilder::new(ZITADEL_URL)
+            .with_access_token("token")
+            .get_chained_interceptor();
+        let request = Request::new(());
+
+        assert!(request.metadata().is_empty());
+
+        let request = interceptor.call(request).unwrap();
+
+        assert!(request.metadata().contains_key("authorization"));
+        assert_eq!(
+            request.metadata().get("authorization").unwrap(),
+            "Bearer token"
+        );
     }
 
-    /// Create a new [`ManagementServiceClient`] to access the
-    /// [Management API](https://docs.zitadel.com/docs/apis/proto/management) of ZITADEL.
-    ///
-    /// This client has the [`AccessTokenInterceptor`][crate::api::interceptors::AccessTokenInterceptor] attached that
-    /// allows authentication against the ZITADEL API with some access token.
-    /// This could be a personal access token of a service account.
-    ///
-    /// ### Errors
-    ///
-    /// This function returns a [`ClientError`] if the provided API endpoint
-    /// cannot be parsed into a valid URL or if the connection to the endpoint
-    /// is not possible.
-    ///
-    /// ### Example
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-    /// let client = zitadel::api::clients::with_access_token::create_management_client(ZITADEL_URL, "token").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "api")]
-    pub async fn create_management_client(
-        api_endpoint: &str,
-        access_token: &str,
-    ) -> Result<
-        ManagementServiceClient<InterceptedService<Channel, AccessTokenInterceptor>>,
-        ClientError,
-    > {
-        let channel = get_channel(api_endpoint).await?;
-        Ok(ManagementServiceClient::with_interceptor(
-            channel,
-            AccessTokenInterceptor::new(access_token),
-        ))
-    }
-}
+    #[test]
+    fn client_builder_with_service_account_attaches_token() {
+        let sa = ServiceAccount::load_from_json(SERVICE_ACCOUNT).unwrap();
+        let mut interceptor = ClientBuilder::new(ZITADEL_URL)
+            .with_service_account(&sa, None)
+            .get_chained_interceptor();
+        let request = Request::new(());
 
-/// Module with convenience functions to create clients for ZITADEL
-/// API access with [`ServiceAccount`][crate::credentials::ServiceAccount]
-/// authentication. Provide a service account JWT profile to create
-/// a gRPC service client that fetches a valid access token from ZITADEL.
-#[cfg(all(feature = "api", feature = "interceptors", feature = "credentials"))]
-pub mod with_service_account {
-    use tonic::codegen::InterceptedService;
-    use tonic::transport::Channel;
+        assert!(request.metadata().is_empty());
 
-    use crate::api::interceptors::ServiceAccountInterceptor;
-    use crate::api::zitadel::{
-        admin::v1::admin_service_client::AdminServiceClient,
-        auth::v1::auth_service_client::AuthServiceClient,
-        management::v1::management_service_client::ManagementServiceClient,
-    };
-    use crate::credentials::{AuthenticationOptions, ServiceAccount};
+        let request = interceptor.call(request).unwrap();
 
-    use super::{get_channel, ClientError};
-
-    /// Create a new [`AdminServiceClient`] to access the
-    /// [Admin API](https://docs.zitadel.com/docs/apis/proto/admin) of ZITADEL.
-    ///
-    /// This client has the [`ServiceAccountInterceptor`][crate::api::interceptors::ServiceAccountInterceptor]
-    /// attached that fetches a valid access token with a service account JWT profile from ZITADEL.
-    /// The provided `api_endpoint` is used as audience for the service account token.
-    ///
-    /// ### Errors
-    ///
-    /// This function returns a [`ClientError`] if the provided API endpoint
-    /// cannot be parsed into a valid URL or if the connection to the endpoint
-    /// is not possible.
-    ///
-    /// ### Example
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-    /// # let service_account = zitadel::credentials::ServiceAccount::load_from_json(r#"{"keyId": "1337", "userId": "42", "key": "foobar"}"#)?;
-    /// let client = zitadel::api::clients::with_service_account::create_admin_client(ZITADEL_URL, &service_account, None).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "api")]
-    pub async fn create_admin_client(
-        api_endpoint: &str,
-        service_account: &ServiceAccount,
-        auth_options: Option<AuthenticationOptions>,
-    ) -> Result<
-        AdminServiceClient<InterceptedService<Channel, ServiceAccountInterceptor>>,
-        ClientError,
-    > {
-        let channel = get_channel(api_endpoint).await?;
-        Ok(AdminServiceClient::with_interceptor(
-            channel,
-            ServiceAccountInterceptor::new(api_endpoint, service_account, auth_options),
-        ))
-    }
-
-    /// Create a new [`AuthServiceClient`] to access the
-    /// [Auth API](https://docs.zitadel.com/docs/apis/proto/auth) of ZITADEL.
-    ///
-    /// This client has the [`ServiceAccountInterceptor`][crate::api::interceptors::ServiceAccountInterceptor]
-    /// attached that fetches a valid access token with a service account JWT profile from ZITADEL.
-    /// The provided `api_endpoint` is used as audience for the service account token.
-    ///
-    /// ### Errors
-    ///
-    /// This function returns a [`ClientError`] if the provided API endpoint
-    /// cannot be parsed into a valid URL or if the connection to the endpoint
-    /// is not possible.
-    ///
-    /// ### Example
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-    /// # let service_account = zitadel::credentials::ServiceAccount::load_from_json(r#"{"keyId": "1337", "userId": "42", "key": "foobar"}"#)?;
-    /// let client = zitadel::api::clients::with_service_account::create_auth_client(ZITADEL_URL, &service_account, None).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "api")]
-    pub async fn create_auth_client(
-        api_endpoint: &str,
-        service_account: &ServiceAccount,
-        auth_options: Option<AuthenticationOptions>,
-    ) -> Result<
-        AuthServiceClient<InterceptedService<Channel, ServiceAccountInterceptor>>,
-        ClientError,
-    > {
-        let channel = get_channel(api_endpoint).await?;
-        Ok(AuthServiceClient::with_interceptor(
-            channel,
-            ServiceAccountInterceptor::new(api_endpoint, service_account, auth_options),
-        ))
-    }
-
-    /// Create a new [`ManagementServiceClient`] to access the
-    /// [Management API](https://docs.zitadel.com/docs/apis/proto/management) of ZITADEL.
-    ///
-    /// This client has the [`ServiceAccountInterceptor`][crate::api::interceptors::ServiceAccountInterceptor]
-    /// attached that fetches a valid access token with a service account JWT profile from ZITADEL.
-    /// The provided `api_endpoint` is used as audience for the service account token.
-    ///
-    /// ### Errors
-    ///
-    /// This function returns a [`ClientError`] if the provided API endpoint
-    /// cannot be parsed into a valid URL or if the connection to the endpoint
-    /// is not possible.
-    ///
-    /// ### Example
-    /// ```
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
-    /// # let service_account = zitadel::credentials::ServiceAccount::load_from_json(r#"{"keyId": "1337", "userId": "42", "key": "foobar"}"#)?;
-    /// let client = zitadel::api::clients::with_service_account::create_management_client(ZITADEL_URL, &service_account, None).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "api")]
-    pub async fn create_management_client(
-        api_endpoint: &str,
-        service_account: &ServiceAccount,
-        auth_options: Option<AuthenticationOptions>,
-    ) -> Result<
-        ManagementServiceClient<InterceptedService<Channel, ServiceAccountInterceptor>>,
-        ClientError,
-    > {
-        let channel = get_channel(api_endpoint).await?;
-        Ok(ManagementServiceClient::with_interceptor(
-            channel,
-            ServiceAccountInterceptor::new(api_endpoint, service_account, auth_options),
-        ))
+        assert!(request.metadata().contains_key("authorization"));
+        assert!(!request
+            .metadata()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .is_empty());
     }
 }

--- a/src/api/clients.rs
+++ b/src/api/clients.rs
@@ -94,6 +94,8 @@ impl ClientBuilder {
         // self.access_token = Some(access_token.to_string());
         // self.service_account = None;
         // self.auth_options = None;
+        // TODO: https://github.com/hyperium/tonic/issues/730
+        // https://blog.cloudflare.com/pin-and-unpin-in-rust
         self
     }
 

--- a/src/api/interceptors.rs
+++ b/src/api/interceptors.rs
@@ -10,6 +10,17 @@ use tonic::{service::Interceptor, Request, Status};
 
 use crate::credentials::{AuthenticationOptions, ServiceAccount};
 
+/// A simple noop interceptor that implements the Interceptor trait.
+/// This allows the client builder to always return an intercepted
+/// client.
+pub(crate) struct NoopInterceptor;
+
+impl Interceptor for NoopInterceptor {
+    fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
+        Ok(request)
+    }
+}
+
 /// Simple gRPC `Interceptor` that attaches a given access token to any request
 /// a client sends. The token is attached with the `Bearer` auth-scheme.
 ///


### PR DESCRIPTION
This allows the new v2 APIs of ZITADEL to be used.

BREAKING CHANGE: The modules for client instantiation
have changed. There is no module "with access token"
or "with service account" anymore. Instead, there is a
centralized `ClientBuilder` in the clients module of the
api to create and configure the gRPC clients. The new
builder allows configuring auth methods beforehand
and then create the according client out of it.
