### PR TITLE
Expose `IntrospectionConfig` to facilitate creating Axum substates

### DIFF
--- a/src/axum/introspection/state.rs
+++ b/src/axum/introspection/state.rs
@@ -8,6 +8,12 @@ pub struct IntrospectionState {
     pub(crate) config: IntrospectionConfig,
 }
 
+impl IntrospectionState {
+    pub fn config(&self) -> &IntrospectionConfig {
+        &self.config
+    }
+}
+
 /// Configuration that must be inject into the axum application state. Used by the
 /// [IntrospectionStateBuilder](super::IntrospectionStateBuilder). This struct is also used to create the [IntrospectionState](IntrospectionState)
 #[derive(Debug, Clone)]


### PR DESCRIPTION
# Problem 
Can't inject other dependencies while using `IntrospectionState` as the only state in Axum. Embedding `IntrospectionState` in an `AppState` object that includes other dependencies renders `IntrospectedUser` unusable since it would require an implementation for `FromRef<AppState> for IntrospectionConfig` which in its turn not possible due to `IntrospectionConfig` inside `IntrospectionState` not being public/does not have a public getter.

# Solution 
Since `IntrospectionState` is built using `IntrospectionStateBuilder` it doesn't make sense to expose the field directly. A getter makes more sense :) 

# Usage Example 
```rust
struct AppState {
    some_other_dep: String,
    introspection_state: IntrospectionState,
}

impl FromRef<AppState> for IntrospectionConfig {
    fn from_ref(input: &AppState) -> Self {
        input.introspection_state.config.clone()
    }
}
```