### PR TITLE
Add Send bound to interceptors

### DIFF
--- a/src/api/clients.rs
+++ b/src/api/clients.rs
@@ -46,7 +46,7 @@ enum AuthType {
 /// stays the same and is not dependent on the authentication type used.
 /// The builder can always return `Client<InterceptedService<Channel, ChainedInterceptor>>`.
 pub struct ChainedInterceptor {
-    interceptors: Vec<Box<dyn Interceptor>>,
+    interceptors: Vec<Box<dyn Interceptor + Send>>,
 }
 
 impl ChainedInterceptor {
@@ -56,7 +56,7 @@ impl ChainedInterceptor {
         }
     }
 
-    pub(crate) fn add_interceptor(mut self, interceptor: Box<dyn Interceptor>) -> Self {
+    pub(crate) fn add_interceptor(mut self, interceptor: Box<dyn Interceptor + Send>) -> Self {
         self.interceptors.push(interceptor);
         self
     }

--- a/src/oidc/introspection/cache/in_memory.rs
+++ b/src/oidc/introspection/cache/in_memory.rs
@@ -61,7 +61,7 @@ mod tests {
     #![allow(clippy::all)]
 
     use crate::oidc::introspection::cache::IntrospectionCache;
-    use chrono::{Duration, Utc};
+    use chrono::{TimeDelta, Utc};
 
     use super::*;
 
@@ -120,7 +120,7 @@ mod tests {
         let t = &c as &dyn IntrospectionCache;
 
         let mut response = Response::new(true, Default::default());
-        response.set_exp(Some(Utc::now() - Duration::seconds(10)));
+        response.set_exp(Some(Utc::now() - TimeDelta::try_seconds(10).unwrap()));
 
         t.set("token1", response.clone()).await;
         t.set("token2", response.clone()).await;


### PR DESCRIPTION
Autoderived Send implementations are lost when using trait objects. Missing Send bounds can be an issue in async contexts and there doesn't appear to be a reason not to introduce it within this repo.