### PR TITLE
feat(actix): add support for actix framework

### DIFF
--- a/.kreya/actix/Authorized Request.krop
+++ b/.kreya/actix/Authorized Request.krop
@@ -1,0 +1,17 @@
+{
+  "details": {
+    "path": "/authed",
+    "method": "GET",
+    "headers": [],
+    "pathParams": []
+  },
+  "requests": [
+    {
+      "contentType": "none"
+    }
+  ],
+  "authId": "483e44fe-3c97-4e75-9ec8-0237764b6a3b",
+  "operationType": "unary",
+  "invokerName": "rest",
+  "typeHint": "GET"
+}

--- a/.kreya/actix/Unauthorized Request.krop
+++ b/.kreya/actix/Unauthorized Request.krop
@@ -1,0 +1,16 @@
+{
+  "details": {
+    "path": "/unauthed",
+    "method": "GET",
+    "headers": [],
+    "pathParams": []
+  },
+  "requests": [
+    {
+      "contentType": "none"
+    }
+  ],
+  "operationType": "unary",
+  "invokerName": "rest",
+  "typeHint": "GET"
+}

--- a/.kreya/actix/directory.krpref
+++ b/.kreya/actix/directory.krpref
@@ -1,0 +1,12 @@
+{
+  "settings": [
+    {
+      "options": {
+        "rest": {
+          "endpoint": "http://127.0.0.1:8080",
+          "pathParams": []
+        }
+      }
+    }
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ include = [
 [features]
 default = []
 
+## Feature that enables support for the [actix framework](https://actix.rs/).
+actix = ["credentials", "oidc", "dep:actix-web"]
+
 ## The API feature enables the gRPC service clients to access the ZITADEL API.
 api = ["dep:prost", "dep:prost-types", "dep:tonic", "dep:tonic-types", "dep:pbjson-types"]
 
@@ -52,6 +55,7 @@ oidc = ["credentials", "dep:base64-compat"]
 rocket = ["credentials", "oidc", "dep:rocket"]
 
 [dependencies]
+actix-web = { version = "4.5.1", optional = true }
 async-trait = { version = "0.1.78", optional = true }
 axum = { version = "0.7", optional = true, features = ["macros"] }
 axum-extra = { version = "0.9", optional = true, features = ["typed-header"] }

--- a/examples/actix_webapi_oauth_interception_basic.rs
+++ b/examples/actix_webapi_oauth_interception_basic.rs
@@ -1,0 +1,39 @@
+use actix_web::{get, App, HttpResponse, HttpServer, Responder};
+use zitadel::actix::introspection::{IntrospectedUser, IntrospectionConfigBuilder};
+
+#[get("/unauthed")]
+async fn unauthed() -> impl Responder {
+    println!("Hello Unauthorized User!");
+    HttpResponse::Ok().body("Hello Unauthorized User!")
+}
+
+#[get("/authed")]
+async fn authed(user: IntrospectedUser) -> impl Responder {
+    println!("Hello Authorized User!");
+    format!(
+        "Hello Authorized {:?} with id {}",
+        user.username, user.user_id
+    )
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    println!("Starting server.");
+    let auth = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
+        .with_basic_auth(
+            "194339055499018497@zitadel_rust_test",
+            "Ip56oGzxKL1rJ8JaleUVKL7qUlpZ1tqHQYRSd6JE1mTlTJ3pDkDzoObHdZsOg88B",
+        )
+        .build()
+        .await
+        .unwrap();
+    HttpServer::new(move || {
+        App::new()
+            .app_data(auth.clone())
+            .service(unauthed)
+            .service(authed)
+    })
+    .bind(("0.0.0.0", 8080))?
+    .run()
+    .await
+}

--- a/src/actix/introspection/config.rs
+++ b/src/actix/introspection/config.rs
@@ -3,8 +3,8 @@ use openidconnect::IntrospectionUrl;
 use crate::oidc::introspection::AuthorityAuthentication;
 
 /// Configuration that must be injected into
-/// [the managed global state](https://rocket.rs/v0.5-rc/guide/state/#managed-state) of the
-/// rocket instance to enable the OAuth token introspection authentication method.
+/// [state](https://actix.rs/docs/application#state) of actix 
+/// to enable the OAuth token introspection authentication method.
 ///
 /// Use the [IntrospectionConfigBuilder](super::IntrospectionConfigBuilder)
 /// to construct a config.

--- a/src/actix/introspection/config.rs
+++ b/src/actix/introspection/config.rs
@@ -1,0 +1,16 @@
+use openidconnect::IntrospectionUrl;
+
+use crate::oidc::introspection::AuthorityAuthentication;
+
+/// Configuration that must be injected into
+/// [the managed global state](https://rocket.rs/v0.5-rc/guide/state/#managed-state) of the
+/// rocket instance to enable the OAuth token introspection authentication method.
+///
+/// Use the [IntrospectionConfigBuilder](super::IntrospectionConfigBuilder)
+/// to construct a config.
+#[derive(Clone, Debug)]
+pub struct IntrospectionConfig {
+    pub(crate) authority: String,
+    pub(crate) authentication: AuthorityAuthentication,
+    pub(crate) introspection_uri: IntrospectionUrl,
+}

--- a/src/actix/introspection/config_builder.rs
+++ b/src/actix/introspection/config_builder.rs
@@ -76,7 +76,7 @@ impl IntrospectionConfigBuilder {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
     /// # use zitadel::credentials::Application;
-    /// # use zitadel::rocket::introspection::IntrospectionConfigBuilder;
+    /// # use zitadel::actix::introspection::IntrospectionConfigBuilder;
     /// # const APPLICATION: &str = r#"
     /// #     {
     /// #         "type": "application",
@@ -100,7 +100,7 @@ impl IntrospectionConfigBuilder {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
-    /// # use zitadel::rocket::introspection::IntrospectionConfigBuilder;
+    /// # use zitadel::actix::introspection::IntrospectionConfigBuilder;
     /// let config = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
     ///                 .with_basic_auth(
     ///                     "194339055499018497@zitadel_rust_test",

--- a/src/actix/introspection/config_builder.rs
+++ b/src/actix/introspection/config_builder.rs
@@ -138,3 +138,77 @@ impl IntrospectionConfigBuilder {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::all)]
+
+    use super::*;
+
+    const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
+    const APPLICATION: &str = r#"
+    {
+        "type": "application",
+        "keyId": "181963758610940161",
+        "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwT2YZJytkkZ1DDM3dcu1OA8YPzHu6XR8HotdMNRnV75GhOT4\nB7zDtdtoP8w/1NHHPEJ859e0kYhrrnKikOKLS6fS1KRsmqR5ZvTq8SlZ2mq3RcX2\nebZx5dQt36INij/WXdsBmjM/yfWvqqWBSb0L/186DaWwmmIxoXWe873vxRmlzblg\nGd8Nu07s9YTREbGPbtFVHEUM6xI4oIe8HJ0e1+JBkiGqk31Cogo0FoAxrOAg0Sf4\n5XiUMYIjzqh8673F9SC4IpVxG22mpFk3vDFuAITaStWYbiH2hPJNKWyX9HDCZb1D\nDqa3wZBDiLqWxh22hNZ6ZIe+3UoSGWsPBH+E1wIDAQABAoIBAD2v5QsRPRN57HmF\njAnNir8nimz6CrN53Pl/MbOZypenBSn9UfReXPeb3+6lzCarBPgGnYsBQAJJU16v\n95daym7PVy1Mg+Ll6F9mhe2Qbr+b23+pj2IRTNC6aB6Aw+PDNzJk7GEGRTG6fWZz\nSQ96Cu9tvcGHiBXwjLlnK+PRWU5IsCiLsjT4xBXsMLMw3YOdMK5z58sqr+SnNEyq\nRHoEvi9aC94WrargVB45Yx+81YNW8uQ5rMDmYaJC5a7ENz522SlAuf4T+fAGJ/HE\n/qbZGD4YwlLqAFDgewQ+5tEWEus3zgY2MIR7vN2zXU1Ptk+mQkXZl/Pxdp7q1xU+\nvr/kcykCgYEAy7MiIAzc1ctQDvkk3HiespzdQ/sC7+CGsBzkyubRc9Oq/YR7GfVK\nGTuDEDlWwx92VAvJGDWRa3T426YDyqiPj66uo836sgL15Uigg5afZun2bqGC78le\nBhSy9b+0YDHPa87GxtKt9UmMoB6WdmoPzOkLEEGS7eesmk2DDgY+QSUCgYEA8tr/\n3PawigL1cxuFpcO1lH6XUspGeAo5yB8FXvfW5g50e37LgooIvOFgUlYuchxwr6uh\nW+CUAWmm4farsgvMBMPYw+PbkCTi/xemiiDmMHUYd7sJkTl0JXApq3pZsNMg4Fw/\n29RynmcG8TGe2dkwrWp1aBYjvIHwEHuNHHTTA0sCgYBtSUFAwsXkaj0cm2y8YHZ8\nS46mv1AXFHYOnKHffjDXnLN7ao2FIsXLfdNWa/zxmLqqYtxUAcFwToSJi6szGnZT\nVxvZRFSBFveIOQvtLW1+EH4nYr3WGko4pvhQwrZqea7YH0skNrogBILPEToWc9bg\nUBOgeB31R7uh2X47kvvphQKBgQDWc60dYnniZVp5mwQZrQjbaC4YXaZ8ugrsPPhx\nNEoAPSN/KihrzZiJsjtsec3p1lNrzRNgHqCT3sgPIdPcFa7DRm5UDRIF54zL1gaq\nUwLyJ3TDxdZc928o4DLryc8J5mZRuSRq6t+MIU5wDnFHzhK+EBQ9Jc/I1rU22ONz\nDXaIoQKBgH14Apggo0o4Eo+OnEBRFbbDulaOfVLPTK9rktikbwO1vzDch8kdcwCU\nsvtRXHjDQL93Ih/8S9aDJZoSDulwr3VUsuDiDEb4jfYmP2sbNO4nIJt+SBMhVOXV\nt7E/uWK28X0GL/bIUzSMMgTfdjhXEtJW+s6hQU1fG+9U1qVTQ2R/\n-----END RSA PRIVATE KEY-----\n",
+        "appId": "181963751145079041",
+        "clientId": "181963751145144577@zitadel_rust_test"
+    }"#;
+
+    #[test]
+    fn create_builder_with_authority() {
+        let builder = IntrospectionConfigBuilder::new("auth");
+
+        assert_eq!(builder.authority, "auth");
+        assert!(builder.authentication.is_none());
+    }
+
+    #[test]
+    fn create_builder_with_jwt_auth() {
+        let mut builder = IntrospectionConfigBuilder::new("auth");
+        let builder = builder.with_jwt_profile(Application::load_from_json(APPLICATION).unwrap());
+
+        assert!(builder.authentication.is_some());
+        assert!(matches!(
+            builder.authentication.as_ref().unwrap(),
+            AuthorityAuthentication::JWTProfile { .. }
+        ));
+    }
+
+    #[test]
+    fn create_builder_with_basic_auth() {
+        let mut builder = IntrospectionConfigBuilder::new("auth");
+        let builder = builder.with_basic_auth("foo", "bar");
+
+        assert!(builder.authentication.is_some());
+        assert!(matches!(
+            builder.authentication.as_ref().unwrap(),
+            AuthorityAuthentication::Basic { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_throws_on_missing_auth() {
+        let result = IntrospectionConfigBuilder::new(ZITADEL_URL).build().await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            IntrospectionConfigBuilderError::NoAuthSchema
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_should_introspect_the_authority() {
+        let result = IntrospectionConfigBuilder::new(ZITADEL_URL)
+            .with_jwt_profile(Application::load_from_json(APPLICATION).unwrap())
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.introspection_uri.to_string(),
+            "https://zitadel-libraries-l8boqa.zitadel.cloud/oauth/v2/introspect".to_string()
+        );
+    }
+}

--- a/src/actix/introspection/config_builder.rs
+++ b/src/actix/introspection/config_builder.rs
@@ -1,0 +1,140 @@
+use custom_error::custom_error;
+
+use crate::actix::introspection::config::IntrospectionConfig;
+use crate::credentials::Application;
+use crate::oidc::discovery::{discover, DiscoveryError};
+use crate::oidc::introspection::AuthorityAuthentication;
+
+custom_error! {
+    /// Error type for introspection config builder related errors.
+    pub IntrospectionConfigBuilderError
+        NoAuthSchema = "no authentication for authority defined",
+        Discovery{source: DiscoveryError} = "could not fetch discovery document: {source}",
+        NoIntrospectionUrl = "discovery document did not contain an introspection url",
+}
+
+/// Builder for [IntrospectionConfig]s.
+/// The authority is mandatory when creating the builder.
+/// Then, either one of the authentication mechanisms must be chosen or the
+/// builder will throw an error during [build](IntrospectionConfigBuilder::build).
+pub struct IntrospectionConfigBuilder {
+    authority: String,
+    authentication: Option<AuthorityAuthentication>,
+}
+
+impl IntrospectionConfigBuilder {
+    /// Create a new config builder with the given authority.
+    /// Returns the chainable config builder.
+    pub fn new(authority: &str) -> Self {
+        Self {
+            authority: authority.to_string(),
+            authentication: None,
+        }
+    }
+
+    /// Set the authentication method to [AuthorityAuthentication::Basic].
+    pub fn with_basic_auth(
+        &mut self,
+        client_id: &str,
+        client_secret: &str,
+    ) -> &mut IntrospectionConfigBuilder {
+        self.authentication = Some(AuthorityAuthentication::Basic {
+            client_id: client_id.to_string(),
+            client_secret: client_secret.to_string(),
+        });
+
+        self
+    }
+
+    /// Set the authentication method to [AuthorityAuthentication::JWTProfile]
+    /// by using the given [Application].
+    pub fn with_jwt_profile(
+        &mut self,
+        application: Application,
+    ) -> &mut IntrospectionConfigBuilder {
+        self.authentication = Some(AuthorityAuthentication::JWTProfile { application });
+
+        self
+    }
+
+    /// Build the [IntrospectionConfig]. This asynchronous method fetches the discovery document
+    /// of the ZITADEL instance and gets the introspection endpoint.
+    ///
+    /// ### Errors
+    ///
+    /// The construction may fail if:
+    /// - No authentication ([IntrospectionConfigBuilder::with_basic_auth] or
+    ///   [IntrospectionConfigBuilder::with_jwt_profile]) was set for the config.
+    /// - The [discover] call throws an error.
+    /// - No introspection endpoint is defined in the discovery document.
+    ///
+    /// ### Examples
+    ///
+    /// #### Build config with JWT Profile (recommended)
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
+    /// # use zitadel::credentials::Application;
+    /// # use zitadel::rocket::introspection::IntrospectionConfigBuilder;
+    /// # const APPLICATION: &str = r#"
+    /// #     {
+    /// #         "type": "application",
+    /// #         "keyId": "181963758610940161",
+    /// #         "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwT2YZJytkkZ1DDM3dcu1OA8YPzHu6XR8HotdMNRnV75GhOT4\nB7zDtdtoP8w/1NHHPEJ859e0kYhrrnKikOKLS6fS1KRsmqR5ZvTq8SlZ2mq3RcX2\nebZx5dQt36INij/WXdsBmjM/yfWvqqWBSb0L/186DaWwmmIxoXWe873vxRmlzblg\nGd8Nu07s9YTREbGPbtFVHEUM6xI4oIe8HJ0e1+JBkiGqk31Cogo0FoAxrOAg0Sf4\n5XiUMYIjzqh8673F9SC4IpVxG22mpFk3vDFuAITaStWYbiH2hPJNKWyX9HDCZb1D\nDqa3wZBDiLqWxh22hNZ6ZIe+3UoSGWsPBH+E1wIDAQABAoIBAD2v5QsRPRN57HmF\njAnNir8nimz6CrN53Pl/MbOZypenBSn9UfReXPeb3+6lzCarBPgGnYsBQAJJU16v\n95daym7PVy1Mg+Ll6F9mhe2Qbr+b23+pj2IRTNC6aB6Aw+PDNzJk7GEGRTG6fWZz\nSQ96Cu9tvcGHiBXwjLlnK+PRWU5IsCiLsjT4xBXsMLMw3YOdMK5z58sqr+SnNEyq\nRHoEvi9aC94WrargVB45Yx+81YNW8uQ5rMDmYaJC5a7ENz522SlAuf4T+fAGJ/HE\n/qbZGD4YwlLqAFDgewQ+5tEWEus3zgY2MIR7vN2zXU1Ptk+mQkXZl/Pxdp7q1xU+\nvr/kcykCgYEAy7MiIAzc1ctQDvkk3HiespzdQ/sC7+CGsBzkyubRc9Oq/YR7GfVK\nGTuDEDlWwx92VAvJGDWRa3T426YDyqiPj66uo836sgL15Uigg5afZun2bqGC78le\nBhSy9b+0YDHPa87GxtKt9UmMoB6WdmoPzOkLEEGS7eesmk2DDgY+QSUCgYEA8tr/\n3PawigL1cxuFpcO1lH6XUspGeAo5yB8FXvfW5g50e37LgooIvOFgUlYuchxwr6uh\nW+CUAWmm4farsgvMBMPYw+PbkCTi/xemiiDmMHUYd7sJkTl0JXApq3pZsNMg4Fw/\n29RynmcG8TGe2dkwrWp1aBYjvIHwEHuNHHTTA0sCgYBtSUFAwsXkaj0cm2y8YHZ8\nS46mv1AXFHYOnKHffjDXnLN7ao2FIsXLfdNWa/zxmLqqYtxUAcFwToSJi6szGnZT\nVxvZRFSBFveIOQvtLW1+EH4nYr3WGko4pvhQwrZqea7YH0skNrogBILPEToWc9bg\nUBOgeB31R7uh2X47kvvphQKBgQDWc60dYnniZVp5mwQZrQjbaC4YXaZ8ugrsPPhx\nNEoAPSN/KihrzZiJsjtsec3p1lNrzRNgHqCT3sgPIdPcFa7DRm5UDRIF54zL1gaq\nUwLyJ3TDxdZc928o4DLryc8J5mZRuSRq6t+MIU5wDnFHzhK+EBQ9Jc/I1rU22ONz\nDXaIoQKBgH14Apggo0o4Eo+OnEBRFbbDulaOfVLPTK9rktikbwO1vzDch8kdcwCU\nsvtRXHjDQL93Ih/8S9aDJZoSDulwr3VUsuDiDEb4jfYmP2sbNO4nIJt+SBMhVOXV\nt7E/uWK28X0GL/bIUzSMMgTfdjhXEtJW+s6hQU1fG+9U1qVTQ2R/\n-----END RSA PRIVATE KEY-----\n",
+    /// #         "appId": "181963751145079041",
+    /// #         "clientId": "181963751145144577@zitadel_rust_test"
+    /// #     }"#;
+    /// let config = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
+    ///                 .with_jwt_profile(Application::load_from_json(APPLICATION).unwrap())
+    ///                 .build()
+    ///                 .await?;
+    ///
+    /// println!("{:?}", config);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// #### Build config with Basic Auth
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>>{
+    /// # use zitadel::rocket::introspection::IntrospectionConfigBuilder;
+    /// let config = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
+    ///                 .with_basic_auth(
+    ///                     "194339055499018497@zitadel_rust_test",
+    ///                     "Ip56oGzxKL1rJ8JaleUVKL7qUlpZ1tqHQYRSd6JE1mTlTJ3pDkDzoObHdZsOg88B",
+    ///                 )
+    ///                 .build()
+    ///                 .await?;
+    ///
+    /// println!("{:?}", config);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn build(&mut self) -> Result<IntrospectionConfig, IntrospectionConfigBuilderError> {
+        if self.authentication.is_none() {
+            return Err(IntrospectionConfigBuilderError::NoAuthSchema);
+        }
+
+        let metadata = discover(&self.authority)
+            .await
+            .map_err(|source| IntrospectionConfigBuilderError::Discovery { source })?;
+
+        let introspection_uri = metadata
+            .additional_metadata()
+            .introspection_endpoint
+            .clone();
+
+        if introspection_uri.is_none() {
+            return Err(IntrospectionConfigBuilderError::NoIntrospectionUrl);
+        }
+
+        Ok(IntrospectionConfig {
+            authority: self.authority.clone(),
+            introspection_uri: introspection_uri.unwrap(),
+            authentication: self.authentication.as_ref().unwrap().clone(),
+        })
+    }
+}

--- a/src/actix/introspection/extractor.rs
+++ b/src/actix/introspection/extractor.rs
@@ -1,0 +1,94 @@
+use std::{future::Future, pin::Pin};
+
+use actix_web::dev::Payload;
+use actix_web::error::{ErrorInternalServerError, ErrorUnauthorized};
+use actix_web::{Error, FromRequest, HttpRequest};
+use openidconnect::TokenIntrospectionResponse;
+
+use crate::actix::introspection::config::IntrospectionConfig;
+use crate::oidc::introspection::{introspect, ZitadelIntrospectionResponse};
+
+#[derive(Debug)]
+pub struct IntrospectedUser {
+    /// UserID of the introspected user (OIDC Field "sub").
+    pub user_id: String,
+    pub username: Option<String>,
+    pub name: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub preferred_username: Option<String>,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub locale: Option<String>,
+}
+
+impl From<ZitadelIntrospectionResponse> for IntrospectedUser {
+    fn from(response: ZitadelIntrospectionResponse) -> Self {
+        Self {
+            user_id: response.sub().unwrap().to_string(),
+            username: response.username().map(|s| s.to_string()),
+            name: response.extra_fields().name.clone(),
+            given_name: response.extra_fields().given_name.clone(),
+            family_name: response.extra_fields().family_name.clone(),
+            preferred_username: response.extra_fields().preferred_username.clone(),
+            email: response.extra_fields().email.clone(),
+            email_verified: response.extra_fields().email_verified,
+            locale: response.extra_fields().locale.clone(),
+        }
+    }
+}
+
+impl FromRequest for IntrospectedUser {
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<IntrospectedUser, Error>>>>;
+
+    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
+        let config = req.app_data::<IntrospectionConfig>();
+        if config.is_none() {
+            return Box::pin(async {
+                Err(ErrorInternalServerError("IntrospectionConfig missing"))
+            });
+        }
+
+        let auth = req.headers().get("authorization");
+        if auth.is_none() {
+            return Box::pin(async { Err(ErrorUnauthorized("Authorization header missing")) });
+        }
+
+        let auth = auth.unwrap().to_str();
+        if auth.is_err() {
+            return Box::pin(async { Err(ErrorUnauthorized("Authorization header invalid")) });
+        }
+
+        let token = auth.unwrap();
+        if !token.starts_with("Bearer ") {
+            return Box::pin(async {
+                Err(ErrorUnauthorized("Authorization header has wrong scheme"))
+            });
+        }
+
+        let config = config.unwrap().clone();
+        let token = token.replace("Bearer ", "");
+
+        Box::pin(async move {
+            let result = introspect(
+                &config.introspection_uri,
+                &config.authority,
+                &config.authentication,
+                &token,
+            )
+            .await;
+
+            if let Err(source) = result {
+                return Err(ErrorInternalServerError(source));
+            }
+
+            let result = result.unwrap();
+            match result.active() {
+                true if result.sub().is_some() => Ok(result.into()),
+                false => Err(ErrorUnauthorized("User not active")),
+                _ => Err(ErrorUnauthorized("User not found")),
+            }
+        })
+    }
+}

--- a/src/actix/introspection/extractor.rs
+++ b/src/actix/introspection/extractor.rs
@@ -8,6 +8,10 @@ use openidconnect::TokenIntrospectionResponse;
 use crate::actix::introspection::config::IntrospectionConfig;
 use crate::oidc::introspection::{introspect, ZitadelIntrospectionResponse};
 
+/// Struct for the handler function that requires an authenticated user.
+/// Contains various information about the given token. The fields are optional
+/// since a machine user does not have a profile or (varying by scope) not all
+/// fields are returned from the introspection endpoint.
 #[derive(Debug)]
 pub struct IntrospectedUser {
     /// UserID of the introspected user (OIDC Field "sub").

--- a/src/actix/introspection/extractor.rs
+++ b/src/actix/introspection/extractor.rs
@@ -119,3 +119,114 @@ impl FromRequest for IntrospectedUser {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::all)]
+
+    use actix_web::{get, test, App, Responder};
+
+    use crate::{actix::introspection::IntrospectionConfigBuilder, credentials::Application};
+
+    use super::*;
+
+    const ZITADEL_URL: &str = "https://zitadel-libraries-l8boqa.zitadel.cloud";
+    const PERSONAL_ACCESS_TOKEN: &str =
+        "dEnGhIFs3VnqcQU5D2zRSeiarB1nwH6goIKY0J8MWZbsnWcTuu1C59lW9DgCq1y096GYdXA";
+    const APPLICATION: &str = r#"
+    {
+        "type": "application",
+        "keyId": "181963758610940161",
+        "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwT2YZJytkkZ1DDM3dcu1OA8YPzHu6XR8HotdMNRnV75GhOT4\nB7zDtdtoP8w/1NHHPEJ859e0kYhrrnKikOKLS6fS1KRsmqR5ZvTq8SlZ2mq3RcX2\nebZx5dQt36INij/WXdsBmjM/yfWvqqWBSb0L/186DaWwmmIxoXWe873vxRmlzblg\nGd8Nu07s9YTREbGPbtFVHEUM6xI4oIe8HJ0e1+JBkiGqk31Cogo0FoAxrOAg0Sf4\n5XiUMYIjzqh8673F9SC4IpVxG22mpFk3vDFuAITaStWYbiH2hPJNKWyX9HDCZb1D\nDqa3wZBDiLqWxh22hNZ6ZIe+3UoSGWsPBH+E1wIDAQABAoIBAD2v5QsRPRN57HmF\njAnNir8nimz6CrN53Pl/MbOZypenBSn9UfReXPeb3+6lzCarBPgGnYsBQAJJU16v\n95daym7PVy1Mg+Ll6F9mhe2Qbr+b23+pj2IRTNC6aB6Aw+PDNzJk7GEGRTG6fWZz\nSQ96Cu9tvcGHiBXwjLlnK+PRWU5IsCiLsjT4xBXsMLMw3YOdMK5z58sqr+SnNEyq\nRHoEvi9aC94WrargVB45Yx+81YNW8uQ5rMDmYaJC5a7ENz522SlAuf4T+fAGJ/HE\n/qbZGD4YwlLqAFDgewQ+5tEWEus3zgY2MIR7vN2zXU1Ptk+mQkXZl/Pxdp7q1xU+\nvr/kcykCgYEAy7MiIAzc1ctQDvkk3HiespzdQ/sC7+CGsBzkyubRc9Oq/YR7GfVK\nGTuDEDlWwx92VAvJGDWRa3T426YDyqiPj66uo836sgL15Uigg5afZun2bqGC78le\nBhSy9b+0YDHPa87GxtKt9UmMoB6WdmoPzOkLEEGS7eesmk2DDgY+QSUCgYEA8tr/\n3PawigL1cxuFpcO1lH6XUspGeAo5yB8FXvfW5g50e37LgooIvOFgUlYuchxwr6uh\nW+CUAWmm4farsgvMBMPYw+PbkCTi/xemiiDmMHUYd7sJkTl0JXApq3pZsNMg4Fw/\n29RynmcG8TGe2dkwrWp1aBYjvIHwEHuNHHTTA0sCgYBtSUFAwsXkaj0cm2y8YHZ8\nS46mv1AXFHYOnKHffjDXnLN7ao2FIsXLfdNWa/zxmLqqYtxUAcFwToSJi6szGnZT\nVxvZRFSBFveIOQvtLW1+EH4nYr3WGko4pvhQwrZqea7YH0skNrogBILPEToWc9bg\nUBOgeB31R7uh2X47kvvphQKBgQDWc60dYnniZVp5mwQZrQjbaC4YXaZ8ugrsPPhx\nNEoAPSN/KihrzZiJsjtsec3p1lNrzRNgHqCT3sgPIdPcFa7DRm5UDRIF54zL1gaq\nUwLyJ3TDxdZc928o4DLryc8J5mZRuSRq6t+MIU5wDnFHzhK+EBQ9Jc/I1rU22ONz\nDXaIoQKBgH14Apggo0o4Eo+OnEBRFbbDulaOfVLPTK9rktikbwO1vzDch8kdcwCU\nsvtRXHjDQL93Ih/8S9aDJZoSDulwr3VUsuDiDEb4jfYmP2sbNO4nIJt+SBMhVOXV\nt7E/uWK28X0GL/bIUzSMMgTfdjhXEtJW+s6hQU1fG+9U1qVTQ2R/\n-----END RSA PRIVATE KEY-----\n",
+        "appId": "181963751145079041",
+        "clientId": "181963751145144577@zitadel_rust_test"
+    }"#;
+
+    async fn get_config() -> IntrospectionConfig {
+        IntrospectionConfigBuilder::new(ZITADEL_URL)
+            .with_jwt_profile(Application::load_from_json(APPLICATION).unwrap())
+            .build()
+            .await
+            .unwrap()
+    }
+
+    #[get("/")]
+    async fn route(_user: IntrospectedUser) -> impl Responder {
+        "Hello Actix"
+    }
+
+    #[tokio::test]
+    async fn extractor_fails_if_no_config_present() {
+        let app = test::init_service(App::new().service(route)).await;
+
+        let req = test::TestRequest::default().to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 500);
+
+        let body = test::read_body(resp).await.to_vec();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert_eq!(body, IntrospectionExtractorError::MissingConfig.to_string());
+    }
+
+    #[tokio::test]
+    async fn extractor_fails_if_no_auth_header_present() {
+        let app = test::init_service(App::new().app_data(get_config().await).service(route)).await;
+
+        let req = test::TestRequest::default().to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 401);
+
+        let body = test::read_body(resp).await.to_vec();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert_eq!(body, IntrospectionExtractorError::Unauthorized.to_string());
+    }
+
+    #[tokio::test]
+    async fn extractor_fails_if_non_bearer_auth_header_present() {
+        let app = test::init_service(App::new().app_data(get_config().await).service(route)).await;
+
+        let req = test::TestRequest::default()
+            .insert_header(("authorization", "Basic foobar"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 401);
+
+        let body = test::read_body(resp).await.to_vec();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert_eq!(body, IntrospectionExtractorError::WrongScheme.to_string());
+    }
+
+    #[tokio::test]
+    async fn authentication_fails_on_inactive_token() {
+        let app = test::init_service(App::new().app_data(get_config().await).service(route)).await;
+
+        let req = test::TestRequest::default()
+            .insert_header((
+                "authorization",
+                format!("Bearer {}", "PERSONAL_ACCESS_TOKEN"),
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 401);
+
+        let body = test::read_body(resp).await.to_vec();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert_eq!(body, IntrospectionExtractorError::Inactive.to_string());
+    }
+
+    #[tokio::test]
+    async fn authentication_succeeds_on_valid_token() {
+        let app = test::init_service(App::new().app_data(get_config().await).service(route)).await;
+
+        let req = test::TestRequest::default()
+            .insert_header(("authorization", format!("Bearer {}", PERSONAL_ACCESS_TOKEN)))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+    }
+}

--- a/src/actix/introspection/mod.rs
+++ b/src/actix/introspection/mod.rs
@@ -122,7 +122,7 @@
 
 pub use config::IntrospectionConfig;
 pub use config_builder::{IntrospectionConfigBuilder, IntrospectionConfigBuilderError};
-pub use extractor::IntrospectedUser;
+pub use extractor::{IntrospectedUser, IntrospectionExtractorError};
 
 mod config;
 mod config_builder;

--- a/src/actix/introspection/mod.rs
+++ b/src/actix/introspection/mod.rs
@@ -23,6 +23,7 @@
 //! inject it into rocket.
 //!
 //! ```no_run
+//! # use artix_web::{App, HttpServer};
 //! # use zitadel::credentials::Application;
 //! # use zitadel::actix::introspection::IntrospectionConfigBuilder;
 //! # const APPLICATION: &str = r#"
@@ -34,7 +35,7 @@
 //! #         "clientId": "181963751145144577@zitadel_rust_test"
 //! #     }"#;
 //! #[actix_web::main]
-//! async fn main() -> _ {
+//! async fn main() -> std::io::Result<()> {
 //!     let config = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
 //!         .with_jwt_profile(Application::load_from_json(APPLICATION).unwrap())
 //!         .build()
@@ -58,7 +59,7 @@
 //! OAuth introspection.
 //!
 //! ```no_run
-//! # use zitadel::rocket::introspection::IntrospectedUser;
+//! # use zitadel::actix::introspection::IntrospectedUser;
 //! #[actix_web::get("/authed")]
 //! async fn authed(user: IntrospectedUser) -> impl actix_web::Responder {
 //!     format!(
@@ -71,6 +72,7 @@
 //! ### Full working example with JWT Profile
 //!
 //! ```no_run
+//! use artix_web::{App, HttpServer};
 //! use zitadel::{
 //!     credentials::Application,
 //!     actix::introspection::{IntrospectedUser, IntrospectionConfigBuilder},

--- a/src/actix/introspection/mod.rs
+++ b/src/actix/introspection/mod.rs
@@ -1,3 +1,123 @@
+//! The introspection module allows
+//! [OAuth 2.0 Token Introspection](https://www.rfc-editor.org/rfc/rfc7662) to be used
+//! to authenticate a user against ZITADEL. The typical use-case is a web API that
+//! receives calls from any source (maybe a Single Page Application) and needs to verify
+//! if the given access token is valid and still active.
+//!
+//! In case of [actix-web](https://actix.rs/), ["extractors"](https://actix.rs/docs/extractors) are used to
+//! extract the introspected user from the request. The request must contain a valid
+//! authorization header (bearer token) and is then checked against the configured
+//! authority.
+//!
+//! ### How to use the introspection extractor
+//!
+//! To use the introspection extractor, the following steps must be performed:
+//! - Inject the (introspection-)config into the actix app
+//! - Use the extractor in any route that need to be protected
+//!
+//! #### Configure Actix
+//!
+//! To enable the introspection, an [IntrospectionConfig] must be injected into
+//! the [state](https://actix.rs/docs/application#state) of actix.
+//! First, construct the configuration with the async builder method, and then
+//! inject it into rocket.
+//!
+//! ```no_run
+//! # use zitadel::credentials::Application;
+//! # use zitadel::actix::introspection::IntrospectionConfigBuilder;
+//! # const APPLICATION: &str = r#"
+//! #     {
+//! #         "type": "application",
+//! #         "keyId": "181963758610940161",
+//! #         "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwT2YZJytkkZ1DDM3dcu1OA8YPzHu6XR8HotdMNRnV75GhOT4\nB7zDtdtoP8w/1NHHPEJ859e0kYhrrnKikOKLS6fS1KRsmqR5ZvTq8SlZ2mq3RcX2\nebZx5dQt36INij/WXdsBmjM/yfWvqqWBSb0L/186DaWwmmIxoXWe873vxRmlzblg\nGd8Nu07s9YTREbGPbtFVHEUM6xI4oIe8HJ0e1+JBkiGqk31Cogo0FoAxrOAg0Sf4\n5XiUMYIjzqh8673F9SC4IpVxG22mpFk3vDFuAITaStWYbiH2hPJNKWyX9HDCZb1D\nDqa3wZBDiLqWxh22hNZ6ZIe+3UoSGWsPBH+E1wIDAQABAoIBAD2v5QsRPRN57HmF\njAnNir8nimz6CrN53Pl/MbOZypenBSn9UfReXPeb3+6lzCarBPgGnYsBQAJJU16v\n95daym7PVy1Mg+Ll6F9mhe2Qbr+b23+pj2IRTNC6aB6Aw+PDNzJk7GEGRTG6fWZz\nSQ96Cu9tvcGHiBXwjLlnK+PRWU5IsCiLsjT4xBXsMLMw3YOdMK5z58sqr+SnNEyq\nRHoEvi9aC94WrargVB45Yx+81YNW8uQ5rMDmYaJC5a7ENz522SlAuf4T+fAGJ/HE\n/qbZGD4YwlLqAFDgewQ+5tEWEus3zgY2MIR7vN2zXU1Ptk+mQkXZl/Pxdp7q1xU+\nvr/kcykCgYEAy7MiIAzc1ctQDvkk3HiespzdQ/sC7+CGsBzkyubRc9Oq/YR7GfVK\nGTuDEDlWwx92VAvJGDWRa3T426YDyqiPj66uo836sgL15Uigg5afZun2bqGC78le\nBhSy9b+0YDHPa87GxtKt9UmMoB6WdmoPzOkLEEGS7eesmk2DDgY+QSUCgYEA8tr/\n3PawigL1cxuFpcO1lH6XUspGeAo5yB8FXvfW5g50e37LgooIvOFgUlYuchxwr6uh\nW+CUAWmm4farsgvMBMPYw+PbkCTi/xemiiDmMHUYd7sJkTl0JXApq3pZsNMg4Fw/\n29RynmcG8TGe2dkwrWp1aBYjvIHwEHuNHHTTA0sCgYBtSUFAwsXkaj0cm2y8YHZ8\nS46mv1AXFHYOnKHffjDXnLN7ao2FIsXLfdNWa/zxmLqqYtxUAcFwToSJi6szGnZT\nVxvZRFSBFveIOQvtLW1+EH4nYr3WGko4pvhQwrZqea7YH0skNrogBILPEToWc9bg\nUBOgeB31R7uh2X47kvvphQKBgQDWc60dYnniZVp5mwQZrQjbaC4YXaZ8ugrsPPhx\nNEoAPSN/KihrzZiJsjtsec3p1lNrzRNgHqCT3sgPIdPcFa7DRm5UDRIF54zL1gaq\nUwLyJ3TDxdZc928o4DLryc8J5mZRuSRq6t+MIU5wDnFHzhK+EBQ9Jc/I1rU22ONz\nDXaIoQKBgH14Apggo0o4Eo+OnEBRFbbDulaOfVLPTK9rktikbwO1vzDch8kdcwCU\nsvtRXHjDQL93Ih/8S9aDJZoSDulwr3VUsuDiDEb4jfYmP2sbNO4nIJt+SBMhVOXV\nt7E/uWK28X0GL/bIUzSMMgTfdjhXEtJW+s6hQU1fG+9U1qVTQ2R/\n-----END RSA PRIVATE KEY-----\n",
+//! #         "appId": "181963751145079041",
+//! #         "clientId": "181963751145144577@zitadel_rust_test"
+//! #     }"#;
+//! #[actix_web::main]
+//! async fn main() -> _ {
+//!     let config = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
+//!         .with_jwt_profile(Application::load_from_json(APPLICATION).unwrap())
+//!         .build()
+//!         .await
+//!         .unwrap();
+//!
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             .app_data(config.clone())
+//!             // .service(the services here...)
+//!     })
+//!     .bind(("0.0.0.0", 8080))?
+//!     .run()
+//!     .await
+//! }
+//! ```
+//!
+//! #### Use the extractor
+//!
+//! Simply inject the [IntrospectedUser] into any route that should be protected by
+//! OAuth introspection.
+//!
+//! ```no_run
+//! # use zitadel::rocket::introspection::IntrospectedUser;
+//! #[actix_web::get("/authed")]
+//! async fn authed(user: IntrospectedUser) -> impl actix_web::Responder {
+//!     format!(
+//!         "Hello Authorized {:?} with id {}",
+//!         user.username, user.user_id
+//!     )
+//! }
+//! ```
+//!
+//! ### Full working example with JWT Profile
+//!
+//! ```no_run
+//! use zitadel::{
+//!     credentials::Application,
+//!     actix::introspection::{IntrospectedUser, IntrospectionConfigBuilder},
+//! };
+//!
+//! const APPLICATION: &str = r#"
+//!     {
+//!         "type": "application",
+//!         "keyId": "181963758610940161",
+//!         "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwT2YZJytkkZ1DDM3dcu1OA8YPzHu6XR8HotdMNRnV75GhOT4\nB7zDtdtoP8w/1NHHPEJ859e0kYhrrnKikOKLS6fS1KRsmqR5ZvTq8SlZ2mq3RcX2\nebZx5dQt36INij/WXdsBmjM/yfWvqqWBSb0L/186DaWwmmIxoXWe873vxRmlzblg\nGd8Nu07s9YTREbGPbtFVHEUM6xI4oIe8HJ0e1+JBkiGqk31Cogo0FoAxrOAg0Sf4\n5XiUMYIjzqh8673F9SC4IpVxG22mpFk3vDFuAITaStWYbiH2hPJNKWyX9HDCZb1D\nDqa3wZBDiLqWxh22hNZ6ZIe+3UoSGWsPBH+E1wIDAQABAoIBAD2v5QsRPRN57HmF\njAnNir8nimz6CrN53Pl/MbOZypenBSn9UfReXPeb3+6lzCarBPgGnYsBQAJJU16v\n95daym7PVy1Mg+Ll6F9mhe2Qbr+b23+pj2IRTNC6aB6Aw+PDNzJk7GEGRTG6fWZz\nSQ96Cu9tvcGHiBXwjLlnK+PRWU5IsCiLsjT4xBXsMLMw3YOdMK5z58sqr+SnNEyq\nRHoEvi9aC94WrargVB45Yx+81YNW8uQ5rMDmYaJC5a7ENz522SlAuf4T+fAGJ/HE\n/qbZGD4YwlLqAFDgewQ+5tEWEus3zgY2MIR7vN2zXU1Ptk+mQkXZl/Pxdp7q1xU+\nvr/kcykCgYEAy7MiIAzc1ctQDvkk3HiespzdQ/sC7+CGsBzkyubRc9Oq/YR7GfVK\nGTuDEDlWwx92VAvJGDWRa3T426YDyqiPj66uo836sgL15Uigg5afZun2bqGC78le\nBhSy9b+0YDHPa87GxtKt9UmMoB6WdmoPzOkLEEGS7eesmk2DDgY+QSUCgYEA8tr/\n3PawigL1cxuFpcO1lH6XUspGeAo5yB8FXvfW5g50e37LgooIvOFgUlYuchxwr6uh\nW+CUAWmm4farsgvMBMPYw+PbkCTi/xemiiDmMHUYd7sJkTl0JXApq3pZsNMg4Fw/\n29RynmcG8TGe2dkwrWp1aBYjvIHwEHuNHHTTA0sCgYBtSUFAwsXkaj0cm2y8YHZ8\nS46mv1AXFHYOnKHffjDXnLN7ao2FIsXLfdNWa/zxmLqqYtxUAcFwToSJi6szGnZT\nVxvZRFSBFveIOQvtLW1+EH4nYr3WGko4pvhQwrZqea7YH0skNrogBILPEToWc9bg\nUBOgeB31R7uh2X47kvvphQKBgQDWc60dYnniZVp5mwQZrQjbaC4YXaZ8ugrsPPhx\nNEoAPSN/KihrzZiJsjtsec3p1lNrzRNgHqCT3sgPIdPcFa7DRm5UDRIF54zL1gaq\nUwLyJ3TDxdZc928o4DLryc8J5mZRuSRq6t+MIU5wDnFHzhK+EBQ9Jc/I1rU22ONz\nDXaIoQKBgH14Apggo0o4Eo+OnEBRFbbDulaOfVLPTK9rktikbwO1vzDch8kdcwCU\nsvtRXHjDQL93Ih/8S9aDJZoSDulwr3VUsuDiDEb4jfYmP2sbNO4nIJt+SBMhVOXV\nt7E/uWK28X0GL/bIUzSMMgTfdjhXEtJW+s6hQU1fG+9U1qVTQ2R/\n-----END RSA PRIVATE KEY-----\n",
+//!         "appId": "181963751145079041",
+//!         "clientId": "181963751145144577@zitadel_rust_test"
+//!     }"#;
+//!
+//! #[actix_web::get("/unauthed")]
+//! async fn unauthed() -> impl actix_web::Responder {
+//!     "Hello Unauthorized User"
+//! }
+//!
+//! #[actix_web::get("/authed")]
+//! async fn authed(user: IntrospectedUser) -> impl actix_web::Responder {
+//!     format!(
+//!         "Hello Authorized {:?} with id {}",
+//!         user.username, user.user_id
+//!     )
+//! }
+//!
+//! #[actix_web::main]
+//! async fn main() -> std::io::Result<()> {
+//!     println!("Starting server.");
+//!     let auth = IntrospectionConfigBuilder::new("https://zitadel-libraries-l8boqa.zitadel.cloud")
+//!         .with_jwt_profile(Application::load_from_json(APPLICATION).unwrap())
+//!         .build()
+//!         .await
+//!         .unwrap();
+//!     HttpServer::new(move || {
+//!         App::new()
+//!             .app_data(auth.clone())
+//!             .service(unauthed)
+//!             .service(authed)
+//!     })
+//!     .bind(("0.0.0.0", 8080))?
+//!     .run()
+//!     .await
+//! }
+//! ```
+
 pub use config::IntrospectionConfig;
 pub use config_builder::{IntrospectionConfigBuilder, IntrospectionConfigBuilderError};
 pub use extractor::IntrospectedUser;

--- a/src/actix/introspection/mod.rs
+++ b/src/actix/introspection/mod.rs
@@ -1,0 +1,7 @@
+pub use config::IntrospectionConfig;
+pub use config_builder::{IntrospectionConfigBuilder, IntrospectionConfigBuilderError};
+pub use extractor::IntrospectedUser;
+
+mod config;
+mod config_builder;
+mod extractor;

--- a/src/actix/introspection/mod.rs
+++ b/src/actix/introspection/mod.rs
@@ -23,7 +23,7 @@
 //! inject it into rocket.
 //!
 //! ```no_run
-//! # use artix_web::{App, HttpServer};
+//! # use actix_web::{App, HttpServer};
 //! # use zitadel::credentials::Application;
 //! # use zitadel::actix::introspection::IntrospectionConfigBuilder;
 //! # const APPLICATION: &str = r#"
@@ -72,7 +72,7 @@
 //! ### Full working example with JWT Profile
 //!
 //! ```no_run
-//! use artix_web::{App, HttpServer};
+//! use actix_web::{App, HttpServer};
 //! use zitadel::{
 //!     credentials::Application,
 //!     actix::introspection::{IntrospectedUser, IntrospectionConfigBuilder},

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -1,0 +1,1 @@
+pub mod introspection;

--- a/src/actix/mod.rs
+++ b/src/actix/mod.rs
@@ -1,1 +1,13 @@
+//! This module provides convenience functions and structs to interact with
+//! ZITADEL within the [actix-web framework](https://actix.rs/).
+//!
+//! Actix Web is a powerful, pragmatic, and extremely fast web framework for Rust.
+//! To authenticate a user against ZITADEL,
+//! "extractors" are used to check the incoming request beforehand.
+//!
+//! Refer to the specific authentication method to see further documentation and
+//! examples:
+//!
+//! - To use OAuth 2.0 Token Introspection, head over to the [introspection] module.
+
 pub mod introspection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
 
+#[cfg(feature = "actix")]
+pub mod actix;
 #[cfg(feature = "api")]
 pub mod api;
 #[cfg(feature = "axum")]


### PR DESCRIPTION
Closes #509.

This adds actix-web framework support
for zitadel-rust. For now, only oauth
introspection is supported by using
the provided config and request extractor.
