### PR TITLE
Make api clients with interceptors cloneable

### DIFF
--- a/src/api/clients.rs
+++ b/src/api/clients.rs
@@ -57,7 +57,6 @@ pub struct ClientBuilderWithInterceptor<T: Interceptor> {
     interceptor: T,
 }
 
-
 impl ClientBuilder {
     /// Create a new client builder with the the provided endpoint.
     pub fn new(api_endpoint: &str) -> ClientBuilder {
@@ -75,7 +74,10 @@ impl ClientBuilder {
     /// Clients with this authentication method will have the [`AccessTokenInterceptor`]
     /// attached.
     #[cfg(feature = "interceptors")]
-    pub fn with_access_token(self, access_token: &str) -> ClientBuilderWithInterceptor<AccessTokenInterceptor> {
+    pub fn with_access_token(
+        self,
+        access_token: &str,
+    ) -> ClientBuilderWithInterceptor<AccessTokenInterceptor> {
         ClientBuilderWithInterceptor {
             api_endpoint: self.api_endpoint,
             interceptor: AccessTokenInterceptor::new(access_token),

--- a/src/api/clients.rs
+++ b/src/api/clients.rs
@@ -92,7 +92,7 @@ impl ClientBuilder<NoInterceptor> {
     pub fn with_interceptor<I: Interceptor>(self, interceptor: I) -> ClientBuilder<I> {
         ClientBuilder {
             api_endpoint: self.api_endpoint,
-            interceptor
+            interceptor,
         }
     }
 
@@ -310,6 +310,27 @@ mod tests {
         "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEA9VIWALQqzx1ypi42t7MG4KSOMldD10brsEUjTcjqxhl6TJrP\nsjaNKWArnV/XH+6ZKRd55mUEFFx9VflqdwQtMVPjZKXpV4cFDiPwf1Z1h1DS6im4\nSo7eKR7OGb7TLBhwt7i2UPF4WnxBhTp/M6pG5kCJ1t8glIo5yRbrILXObRmvNWMz\nVIFAyw68NDZGYNhnR8AT43zjeJTFXG/suuEoXO/mMmMjsYY8kS0BbiQeq5t5hIrr\na/odswkDPn5Zd4P91iJHDnYlgfJuo3oRmgpOj/dDsl+vTol+vveeMO4TXPwZcl36\ngUNPok7nd6BA3gqmOS+fMImzmZB42trghARXXwIDAQABAoIBAQCbMOGQcml+ep+T\ntzqQPWYFaLQ37nKRVmE1Mpeh1o+G4Ik4utrXX6EvYpJUzVN29ObZUuufr5nEE7qK\nT+1k+zRntyzr9/VElLrC9kNnGtfg0WWMEvZt3DF4i+9P5CMNCy0LXIOhcxBzFZYR\nZS8hDQArGvrX/nFK5qKlrqTyHXFIHDFa6z59ErhXEnsTgRvx/Mo+6UkdBkHsKnlJ\nAbXqXFbfz6nDsF1DgRra5ODn1k8nZqnC/YcssE7/dlbuByz10ECkOSzqYcfufnsb\n9N1Ld4Xlj3yzsqPFzEJyHHm9eEHQXsPavaXiM64/+zpsksLscEIE/0KtIy5tngpZ\nSCqZAcj5AoGBAPb1bQFWUBmmUuSTtSymsxgXghJiJ3r+jJgdGbkv2IsRTs4En5Sz\n0SbPE1YWmMDDgTacJlB4/XiaojQ/j1EEY17inxYomE72UL6/ET7ycsEw3e9ALuD5\np0y2Sdzes2biH30bw5jD8kJ+hV18T745KtzrwSH4I0lAjnkmiH+0S67VAoGBAP5N\nTtAp/Qdxh9GjNSw1J7KRLtJrrr0pPrJ9av4GoFoWlz+Qw2X3dl8rjG3Bqz9LPV7A\ngiHMel8WTmdIM/S3F4Q3ufEfE+VzG+gncWd9SJfX5/LVhatPzTGLNsY7AYGEpSwT\n5/0anS1mHrLwsVcPrZnigekr5A5mfZl6nxtOnE9jAoGBALACqacbUkmFrmy1DZp+\nUQSptI3PoR3bEG9VxkCjZi1vr3/L8cS1CCslyT1BK6uva4d1cSVHpjfv1g1xA38V\nppE46XOMiUk16sSYPv1jJQCmCHd9givcIy3cefZOTwTTwueTAyv888wKipjfgaIs\n8my0JllEljmeJi0Ylo6V/J7lAoGBAIFqRlmZhLNtC3mcXUsKIhG14OYk9uA9RTMA\nsJpmNOSj6oTm3wndTdhRCT4x+TxUxf6aaZ9ZuEz7xRq6m/ZF1ynqUi5ramyyj9kt\neYD5OSBNODVUhJoSGpLEDjQDg1iucIBmAQHFsYeRGL5nz1hHGkneA87uDzlk3zZk\nOORktReRAoGAGUfU2UfaniAlqrZsSma3ZTlvJWs1x8cbVDyKTYMX5ShHhp+cA86H\nYjSSol6GI2wQPP+qIvZ1E8XyzD2miMJabl92/WY0tHejNNBEHwD8uBZKrtMoFWM7\nWJNl+Xneu/sT8s4pP2ng6QE7jpHXi2TUNmSlgQry9JN2AmA9TuSTW2Y=\n-----END RSA PRIVATE KEY-----\n",
         "userId": "181828061098934529"
     }"#;
+
+    #[tokio::test]
+    async fn clients_are_cloneable() {
+        let access_token_client = ClientBuilder::new(ZITADEL_URL)
+            .with_access_token("token")
+            .build_user_client()
+            .await
+            .unwrap();
+        let _cloned = access_token_client.clone();
+
+        let service_account_client = ClientBuilder::new(ZITADEL_URL)
+            .with_service_account(
+                &ServiceAccount::load_from_json(SERVICE_ACCOUNT).unwrap(),
+                None,
+            )
+            .build_user_client()
+            .await
+            .unwrap();
+
+        let _cloned = service_account_client.clone();
+    }
 
     #[test]
     fn client_builder_with_access_token_attaches_it() {

--- a/src/api/clients.rs
+++ b/src/api/clients.rs
@@ -85,6 +85,17 @@ impl ClientBuilder<NoInterceptor> {
         }
     }
 
+    /// Configure the client builder to inject a custom interceptor,
+    /// which can be used to modify the [Request][tonic::request::Request] before being sent.
+    ///
+    /// See [Interceptor][tonic::service::Interceptor] for more details.
+    pub fn with_interceptor<I: Interceptor>(self, interceptor: I) -> ClientBuilder<I> {
+        ClientBuilder {
+            api_endpoint: self.api_endpoint,
+            interceptor
+        }
+    }
+
     /// Configure the client builder to use a provided access token.
     /// This can be a pre-fetched token from ZITADEL or some other form
     /// of a valid access token like a personal access token (PAT).
@@ -93,10 +104,7 @@ impl ClientBuilder<NoInterceptor> {
     /// attached.
     #[cfg(feature = "interceptors")]
     pub fn with_access_token(self, access_token: &str) -> ClientBuilder<AccessTokenInterceptor> {
-        ClientBuilder {
-            api_endpoint: self.api_endpoint,
-            interceptor: AccessTokenInterceptor::new(access_token),
-        }
+        self.with_interceptor(AccessTokenInterceptor::new(access_token))
     }
 
     /// Configure the client builder to use a [`ServiceAccount`][crate::credentials::ServiceAccount].
@@ -116,10 +124,7 @@ impl ClientBuilder<NoInterceptor> {
             service_account,
             auth_options.clone(),
         );
-        ClientBuilder {
-            api_endpoint: self.api_endpoint,
-            interceptor,
-        }
+        self.with_interceptor(interceptor)
     }
 }
 


### PR DESCRIPTION
Make clients clonable: 

* Remove the chained interceptor
* Make service account interceptor cloneable by managing token with interior mutablity

Note: this is built on top of https://github.com/smartive/zitadel-rust/pull/565