### PR TITLE
Improve introspection cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ interceptors = ["credentials", "dep:time", "dep:tokio"]
 ## By default, only the in-memory cache is available. To use a different cache,
 ## enable specific features of this crate, or implement your own cache with
 ## the trait.
-introspection_cache = ["dep:async-trait", "dep:time"]
+introspection_cache = ["dep:async-trait", "dep:time", "dep:moka"]
 
 ## The OIDC module enables basic OIDC (OpenID Connect) features to communicate
 ## with ZITADEL. Two examples are the `discover` and `introspect` functions.
@@ -146,6 +146,7 @@ base64-compat = { version = "1", optional = true }
 custom_error = "1.9.2"
 document-features = { version = "0.2.8", optional = true }
 jsonwebtoken = { version = "9.3.0", optional = true }
+moka = { version = "0.12.8", features = ["future"], optional = true }
 openidconnect = { version = "3.5.0", optional = true }
 pbjson-types = { version = "0.7.0", optional = true }
 prost = { version = "0.13.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ tonic-types = { version = "0.12.1", optional = true }
 chrono = "0.4.38"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13" }
+http-body-util = "0.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/axum/introspection/mod.rs
+++ b/src/axum/introspection/mod.rs
@@ -1,11 +1,12 @@
-//! The intropection module allows you to use the OAuth 2.0 Token Introspection flow to authenticate users against ZITADEL.
+//! The introspection module allows you to use the OAuth 2.0 Token Introspection flow to authenticate users against ZITADEL.
 //!
-//! Axum uses "extracters" and "middlewares" to intercept calls. To authenticate a user against ZITADEL, you can use the [IntrospectedUser].
+//! Axum uses "extractors" and "middlewares" to intercept calls. To authenticate a user against ZITADEL, you can use the [IntrospectedUser].
 //! Which enables an extractor workflow: [extractor](https://docs.rs/axum/latest/axum/extract/index.html)
 //!
 //! #### Configure Axum
 //!
 //! To use the introspection flow, you need to configure the [IntrospectionState] and add it to your [Router](https://docs.rs/axum/latest/axum/routing/struct.Router.html).
+//! When a custom state is used, [FromRef](axum::extract::FromRef) must be implemented. See [IntrospectionState] for more Details.
 //!
 //! ```no_run
 //! #
@@ -60,6 +61,6 @@ mod state;
 mod state_builder;
 mod user;
 
-pub use state::{IntrospectionConfig, IntrospectionState};
+pub use state::IntrospectionState;
 pub use state_builder::{IntrospectionStateBuilder, IntrospectionStateBuilderError};
 pub use user::{IntrospectedUser, IntrospectionGuardError};

--- a/src/axum/introspection/state.rs
+++ b/src/axum/introspection/state.rs
@@ -1,6 +1,8 @@
 use openidconnect::IntrospectionUrl;
 use std::sync::Arc;
 
+#[cfg(feature = "introspection_cache")]
+use crate::oidc::introspection::cache::IntrospectionCache;
 use crate::oidc::introspection::AuthorityAuthentication;
 
 /// State which must be present for extractor to work,
@@ -32,4 +34,6 @@ pub(crate) struct IntrospectionConfig {
     pub(crate) authority: String,
     pub(crate) authentication: AuthorityAuthentication,
     pub(crate) introspection_uri: IntrospectionUrl,
+    #[cfg(feature = "introspection_cache")]
+    pub(crate) cache: Option<Box<dyn IntrospectionCache>>,
 }

--- a/src/axum/introspection/state.rs
+++ b/src/axum/introspection/state.rs
@@ -1,30 +1,35 @@
-use axum::extract::FromRef;
 use openidconnect::IntrospectionUrl;
+use std::sync::Arc;
 
 use crate::oidc::introspection::AuthorityAuthentication;
 
+/// State which must be present for extractor to work,
+/// compare [axum's official documentation](https://docs.rs/axum/0.6.4/axum/extract/struct.State.html#for-library-authors).
+/// Use [IntrospectionStateBuilder](super::IntrospectionStateBuilder) to configure the respective parameters.
+///
+/// If a custom state is used, then [FromRef](axum::extract::FromRef) must be implemented,
+/// to make the necessary state available.
+///
+/// ```
+/// use axum::extract::FromRef;
+/// use zitadel::axum::introspection::IntrospectionState;
+/// struct UserState {
+///     introspection_state: IntrospectionState
+/// }
+///
+/// impl FromRef<UserState> for IntrospectionState {
+///     fn from_ref(input: &UserState) -> Self {
+///         input.introspection_state.clone()
+///     }
+/// }
 #[derive(Clone, Debug)]
 pub struct IntrospectionState {
-    pub(crate) config: IntrospectionConfig,
+    pub(crate) config: Arc<IntrospectionConfig>,
 }
 
-impl IntrospectionState {
-    pub fn config(&self) -> &IntrospectionConfig {
-        &self.config
-    }
-}
-
-/// Configuration that must be inject into the axum application state. Used by the
-/// [IntrospectionStateBuilder](super::IntrospectionStateBuilder). This struct is also used to create the [IntrospectionState](IntrospectionState)
-#[derive(Debug, Clone)]
-pub struct IntrospectionConfig {
+#[derive(Debug)]
+pub(crate) struct IntrospectionConfig {
     pub(crate) authority: String,
     pub(crate) authentication: AuthorityAuthentication,
     pub(crate) introspection_uri: IntrospectionUrl,
-}
-
-impl FromRef<IntrospectionState> for IntrospectionConfig {
-    fn from_ref(input: &IntrospectionState) -> Self {
-        input.config.clone()
-    }
 }

--- a/src/axum/introspection/state_builder.rs
+++ b/src/axum/introspection/state_builder.rs
@@ -1,4 +1,5 @@
 use custom_error::custom_error;
+use std::sync::Arc;
 
 use crate::axum::introspection::state::IntrospectionConfig;
 use crate::credentials::Application;
@@ -67,11 +68,11 @@ impl IntrospectionStateBuilder {
         }
 
         Ok(IntrospectionState {
-            config: IntrospectionConfig {
+            config: Arc::new(IntrospectionConfig {
                 authority: self.authority.clone(),
                 introspection_uri: introspection_uri.unwrap(),
                 authentication: self.authentication.as_ref().unwrap().clone(),
-            },
+            }),
         })
     }
 }

--- a/src/oidc/introspection/mod.rs
+++ b/src/oidc/introspection/mod.rs
@@ -36,6 +36,34 @@ custom_error! {
 ///   `resource_owner_` are set.
 /// - When scope contains `urn:zitadel:iam:user:metadata`, the metadata hashmap will be
 ///   filled with the user metadata.
+///
+/// It can be used as a basis for further customized authorization checks, for example:
+/// ```
+/// use zitadel::axum::introspection::IntrospectedUser;
+/// use zitadel::oidc::introspection::ZitadelIntrospectionExtraTokenFields;
+///
+/// enum Role {
+///   Admin,
+///   Client
+/// }
+///
+/// trait MyAuthorizationChecks {
+///     fn has_role(&self, role: Role, org_id: &str) -> bool;
+/// }
+///
+/// impl MyAuthorizationChecks for ZitadelIntrospectionExtraTokenFields {
+///     fn has_role(&self, role: Role, org_id: &str) -> bool {
+///         let role = match role {
+///             Role::Admin => "Admin",
+///             Role::Client => "Client",
+///         };
+///         self.project_roles.as_ref()
+///             .and_then(|roles| roles.get(role))
+///             .map(|org_ids| org_ids.contains_key(org_id))
+///             .unwrap_or(false)
+///     }
+/// }
+/// ```
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct ZitadelIntrospectionExtraTokenFields {
     pub name: Option<String>,

--- a/src/rocket/introspection/config.rs
+++ b/src/rocket/introspection/config.rs
@@ -1,6 +1,8 @@
 use openidconnect::IntrospectionUrl;
 
-use crate::oidc::introspection::{cache::IntrospectionCache, AuthorityAuthentication};
+#[cfg(feature = "introspection_cache")]
+use crate::oidc::introspection::cache::IntrospectionCache;
+use crate::oidc::introspection::AuthorityAuthentication;
 
 /// Configuration that must be injected into
 /// [the managed global state](https://rocket.rs/v0.5-rc/guide/state/#managed-state) of the


### PR DESCRIPTION
Main goals of this PR:

* allow to use introspection cache in axum
* improve caching behavior by using a [moka](https://github.com/moka-rs/moka) which is optimized for such scenarios
* introduce a default TTL in minutes as the access token expiry is not desired from a security perspective

To achieve this I had to remove the Role generic type parameter introduced in #550 , as this was incompatible with the type erasure for the IntrospectionCache trait types.
But there are simple ways to achieve the same convenience on library user side.

