### PR TITLE
Add project_roles and metadata to all IntrospectedUser

### DIFF
--- a/src/actix/introspection/extractor.rs
+++ b/src/actix/introspection/extractor.rs
@@ -5,6 +5,7 @@ use actix_web::error::{ErrorInternalServerError, ErrorUnauthorized};
 use actix_web::{Error, FromRequest, HttpRequest};
 use custom_error::custom_error;
 use openidconnect::TokenIntrospectionResponse;
+use std::collections::HashMap;
 
 use crate::actix::introspection::config::IntrospectionConfig;
 use crate::oidc::introspection::{introspect, IntrospectionError, ZitadelIntrospectionResponse};
@@ -37,6 +38,8 @@ pub struct IntrospectedUser {
     pub email: Option<String>,
     pub email_verified: Option<bool>,
     pub locale: Option<String>,
+    pub project_roles: Option<HashMap<String, HashMap<String, String>>>,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 impl From<ZitadelIntrospectionResponse> for IntrospectedUser {
@@ -51,6 +54,8 @@ impl From<ZitadelIntrospectionResponse> for IntrospectedUser {
             email: response.extra_fields().email.clone(),
             email_verified: response.extra_fields().email_verified,
             locale: response.extra_fields().locale.clone(),
+            project_roles: response.extra_fields().project_roles.clone(),
+            metadata: response.extra_fields().metadata.clone(),
         }
     }
 }

--- a/src/axum/introspection/user.rs
+++ b/src/axum/introspection/user.rs
@@ -108,6 +108,7 @@ pub struct IntrospectedUser {
     pub email_verified: Option<bool>,
     pub locale: Option<String>,
     pub project_roles: Option<HashMap<String, HashMap<String, String>>>,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[async_trait]
@@ -193,6 +194,7 @@ impl From<ZitadelIntrospectionResponse> for IntrospectedUser {
             email_verified: response.extra_fields().email_verified,
             locale: response.extra_fields().locale.clone(),
             project_roles: response.extra_fields().project_roles.clone(),
+            metadata: response.extra_fields().metadata.clone(),
         }
     }
 }

--- a/src/rocket/introspection/guard.rs
+++ b/src/rocket/introspection/guard.rs
@@ -3,6 +3,7 @@ use openidconnect::TokenIntrospectionResponse;
 use rocket::http::Status;
 use rocket::request::{FromRequest, Outcome};
 use rocket::{async_trait, Request};
+use std::collections::HashMap;
 
 use crate::oidc::introspection::{introspect, IntrospectionError, ZitadelIntrospectionResponse};
 use crate::rocket::introspection::IntrospectionConfig;
@@ -35,6 +36,8 @@ pub struct IntrospectedUser {
     pub email: Option<String>,
     pub email_verified: Option<bool>,
     pub locale: Option<String>,
+    pub project_roles: Option<HashMap<String, HashMap<String, String>>>,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 impl From<ZitadelIntrospectionResponse> for IntrospectedUser {
@@ -49,6 +52,8 @@ impl From<ZitadelIntrospectionResponse> for IntrospectedUser {
             email: response.extra_fields().email.clone(),
             email_verified: response.extra_fields().email_verified,
             locale: response.extra_fields().locale.clone(),
+            project_roles: response.extra_fields().project_roles.clone(),
+            metadata: response.extra_fields().metadata.clone(),
         }
     }
 }


### PR DESCRIPTION
Adds `project_roles` and `metadata` fields to all three `IntrospectedUser` structs

Closes #568 
Closes #569 