### PR TITLE
fix(deps): update axum monorepo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,8 +146,8 @@ proto_full = ["zitadel-action-v1","zitadel-admin-v1","zitadel-app-v1","zitadel-a
 [dependencies]
 actix-web = { version = "4.5.1", optional = true }
 async-trait = { version = "0.1.80", optional = true }
-axum = { version = "0.7.5", optional = true, features = ["macros"] }
-axum-extra = { version = "0.9.3", optional = true, features = ["typed-header"] }
+axum = { version = "0.8.0", optional = true, features = ["macros"] }
+axum-extra = { version = "0.10.0", optional = true, features = ["typed-header"] }
 base64-compat = { version = "1", optional = true }
 custom_error = "1.9.2"
 document-features = { version = "0.2.8", optional = true }

--- a/src/axum/introspection/user.rs
+++ b/src/axum/introspection/user.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 use crate::axum::introspection::IntrospectionState;
 use axum::http::StatusCode;
 use axum::{
-    async_trait,
     extract::{FromRef, FromRequestParts},
     http::request::Parts,
     response::IntoResponse,
@@ -111,7 +110,6 @@ pub struct IntrospectedUser {
     pub metadata: Option<HashMap<String, String>>,
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for IntrospectedUser
 where
     IntrospectionState: FromRef<S>,


### PR DESCRIPTION
Removed `async_trait` which blocked the renovate PR.