### PR TITLE
Apply tls-roots cargo feature to reqwest

### DIFF
--- a/crates/zitadel/Cargo.toml
+++ b/crates/zitadel/Cargo.toml
@@ -55,7 +55,7 @@ api-settings-v2 = ["api-common", "zitadel-gen/zitadel-settings-v2" ]
 api-user-v2 = ["api-common", "zitadel-gen/zitadel-user-v2" ]
 
 
-tls-roots = ["tonic/tls-roots"]
+tls-roots = ["tonic/tls-roots", "reqwest/rustls-tls-native-roots"]
 tls-webpki-roots = ["tonic/tls-webpki-roots"]
 
 


### PR DESCRIPTION
The tls-roots feature makes axum discover system TLS certificates through rustls-native-certs, but not reqwest. This PR changes that so that the corresponding feature on reqwest is activated as well, so e.g. oidc discovery requests behave the same as gRPC requests with regards to TLS certificates.