### PR TITLE
fix: drop incorrect api guard when using individual api features

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,7 +9,6 @@ pub use generated::zitadel;
 
 pub mod clients;
 #[allow(clippy::all)]
-#[cfg(feature = "api")]
 mod generated;
 #[cfg(feature = "interceptors")]
 pub mod interceptors;


### PR DESCRIPTION
api features are already guraded by api-common feature flag